### PR TITLE
Update MerlinAU.sh (Better memory management)

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1162,7 +1162,7 @@ change_build_type() {
     fi
 
     printf "Current Build Type: ${GRNct}$display_choice${NOct}.\n"
-	printf "Would you like to use the original ${REDct}ROG${NOct} themed user interface?${NOct}\n"
+    printf "Would you like to use the original ${REDct}ROG${NOct} themed user interface?${NOct}\n"
 	
 	while true; do
 		printf "\n [${theExitStr}] Enter your choice (y/n): "
@@ -1611,7 +1611,7 @@ _RunFirmwareUpdateNow_()
     if ! release_version="$(_GetLatestFWUpdateVersionFromRouter_)" || \
        ! _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
     then
-       Say "No new firmware version update is found for [$PRODUCT_ID] router model."
+        Say "No new firmware version update is found for [$PRODUCT_ID] router model."
         "$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
         return 1
     fi

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2021-Nov-01
-# Last Modified: 2023-Dec-09
+# Last Modified: 2023-Dec-10
 ###################################################################
 set -u
 
@@ -1127,7 +1127,7 @@ _GetLatestFWUpdateVersionFromWebsite_()
 }
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2023-Dec-05] ##
+## Modified by ExtremeFiretop [2023-Dec-10] ##
 ##------------------------------------------##
 change_build_type() {
     echo "Changing Build Type..."
@@ -1147,10 +1147,12 @@ change_build_type() {
         display_choice="Pure Build"
     fi
 
-    printf "Current Build Type: ${GRNct}$display_choice. ${REDct}Use ROG build? (y/n)${NOct}\n"
-
+    printf "Current Build Type: ${GRNct}$display_choice${NOct}.\n"
+	printf "Would you like to use the original ${REDct}ROG${NOct} themed user interface?${NOct}\n"
+	
 	while true; do
-		read -rp "Enter your choice (y/n) or e=Exit to main menu: " choice
+		printf "\n [${theExitStr}] Enter your choice (y/n): "
+		read -r choice
 		choice="${choice:-$previous_choice}"
 		choice="$(echo "$choice" | tr '[:upper:]' '[:lower:]')"
 
@@ -2020,7 +2022,7 @@ FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
 FW_InstalledVersion="${GRNct}$(_GetCurrentFWInstalledLongVersion_)${NOct}"
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2023-Dec-05] ##
+## Modified by ExtremeFiretop [2023-Dec-10] ##
 ##------------------------------------------##
 show_menu()
 {
@@ -2047,7 +2049,7 @@ show_menu()
    printf "\n${padStr}USB Storage Connected: $USBConnected"
 
    printf "\n${SEPstr}"
-   printf "\n  ${GRNct}1${NOct}.  Run Update F/W Check Now\n"
+   printf "\n  ${GRNct}1${NOct}.  Run F/W Update Check Now\n"
    printf "\n  ${GRNct}2${NOct}.  Configure Router Login Credentials\n"
 
    # Enable/Disable the ASUS Router's built-in "F/W Update Check" #
@@ -2068,10 +2070,10 @@ show_menu()
    printf "\n  ${GRNct}5${NOct}.  Set F/W Update Check Schedule"
    printf "\n      [Current Schedule: ${GRNct}${FW_UpdateCronJobSchedule}${NOct}]\n"
 
-   printf "\n  ${GRNct}6${NOct}.  Set Directory Path for F/W Update ZIP File"
+   printf "\n  ${GRNct}6${NOct}.  Set Directory for F/W Update ZIP File"
    printf "\n      [Current Path: ${GRNct}${FW_ZIP_DIR}${NOct}]\n"
 
-   printf "\n  ${GRNct}7${NOct}.  Set Directory Path for F/W Update Log Files"
+   printf "\n  ${GRNct}7${NOct}.  Set Directory for F/W Update Log Files"
    printf "\n      [Current Path: ${GRNct}${FW_LOG_DIR}${NOct}]\n"
 
    # Retrieve the current build type setting

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -944,7 +944,7 @@ _GetCurrentFWInstalledShortVersion_()
 get_free_ram() {
     # Using awk to sum up the 'free', 'buffers', and 'cached' columns.
     free | awk '/^Mem:/{print $4}'  # This will return the available memory in kilobytes.
-	##FOR DEBUG ONLY##echo 1000
+    ##FOR DEBUG ONLY##echo 1000
 }
 
 ##---------------------------------------##

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---WORK IN PROGRESS--- 
 - PREVIEW, NOT YET COMPLETE. PLEASE EXPECT BUGS.
 
-![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/24496690-8156-41a2-b7fb-5200e76fcdd3)
+![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/e948e3c3-9068-41ab-b8dc-3678a6eb4a68)
 
 ---TESTERS NEEDED!--- 
  - If you see your router listed as untested below, feel free to test and report any issues.

--- a/README.md
+++ b/README.md
@@ -51,21 +51,16 @@
 
 ## Remaining/Planned Features:
       
-1. Check Memory:
- - Before downloading the ZIP file into the router's "$HOME" folder (instead of a USB-attached drive), the router may already be in a "low free RAM" state, depending on the number of processes & extra add-ons running as well as other factors that slowly consume RAM over time (more so if the router's uptime is several weeks or months).
-
- - After just downloading the ZIP file into the router's "$HOME" folder, there may not be enough free RAM to continue to uncompress & extract the F/W files into the same $HOME folder. For such cases, we might need to check available free RAM before the ZIP file is downloaded, and then again before uncompressing/extracting the files, especially if using the router's "$HOME" directory for all of it, and not the USB drive at all.
- 
- - - Notes:
- - - Might need to add some "overhead" to the file size comparison to account for the "ZIP + F/W" files being on the "$HOME" directory at the same time, even if just temporarily.
- - - New routers use UBIFS instead of JFFS2.
-
-2. System Notifications:
+1. System Notifications:
 
 - Possibly trigger the hardcoded notification in the GUI's upper right corner.
 
-3. AMTM Install:
+2. AMTM Install:
 - Only once it's been vetted through most routers.
+
+- Notes:
+  - Might need to add some "overhead" to the file size comparison to account for the "ZIP + F/W" files being on the "$HOME" directory at the same time, even if just temporarily.
+  - New routers use UBIFS instead of JFFS2.
 
 ## Merlin(A)uto(U)pdate
 


### PR DESCRIPTION
@Martinski4GitHub 

How do we feel about this solution for better memory management?
It now dynamically assigns the required memory based on the size of the zip. (Includes a 10MB overhead for the zip file) and it's checked 3 times instead of once. 

1. Once before the download.
2. Once before the decompress.
3. Once before the actual flash.

Basically making sure that every step along the way, the router maintains this required memory or it prompts for reboot.

I added debug code for the "get_free_ram()" function so we can test without actually being low on memory. Just make the script think it is.

Only concern I have is in the notes in the readme it says:
**-Might need to add some "overhead" to the file size comparison to account for the "ZIP + F/W" files being on the "$HOME" directory at the same time, even if just temporarily.**

Not sure if I'm correctly accounting for this. I remember you mentioning this, but I'm not sure I'm understanding correctly. 
Are we saying we need to up the RAM requirement for when we decompress the zip file? 

(aka lets say the .zip file is 150MB so right now it would do 150MB+10MB overhead for 160MB memory required, are we saying we need to up this overhead for the decompression step?)