### PR TITLE
Update MerlinAU.sh with Memory Warnings

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -8,7 +8,7 @@
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION="0.2.27"
+readonly SCRIPT_VERSION="0.2.30"
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -947,9 +947,9 @@ _GetCurrentFWInstalledShortVersion_()
 ##-------------------------------------##
 _HasRouterMoreThan256MBtotalRAM_()
 {
-   #local totalRAM_KB
-   #totalRAM_KB="$(cat /proc/meminfo | awk -F ' ' '/^MemTotal: /{print $2}')"
-   #[ -n "$totalRAM_KB" ] && [ "$totalRAM_KB" -gt 262144 ] && return 0
+   local totalRAM_KB
+   totalRAM_KB="$(cat /proc/meminfo | awk -F ' ' '/^MemTotal: /{print $2}')"
+   [ -n "$totalRAM_KB" ] && [ "$totalRAM_KB" -gt 262144 ] && return 0
    return 1
 }
 
@@ -1635,8 +1635,8 @@ _RunFirmwareUpdateNow_()
        ! _CreateDirectory_ "$FW_BIN_DIR" ; then return 1 ; fi
 
     # Get current firmware version #
-    ##FOR DEBUG ONLYcurrent_version="$(_GetCurrentFWInstalledShortVersion_)"
-    current_version="388.3.0"
+    current_version="$(_GetCurrentFWInstalledShortVersion_)"
+    ##FOR DEBUG ONLY##current_version="388.3.0"
 
     #---------------------------------------------------------#
     # If the "F/W Update Check" in the WebGUI is disabled 
@@ -1659,13 +1659,13 @@ _RunFirmwareUpdateNow_()
     # "New F/W Release Version" from the router itself.
     # If no new F/W version update is available exit.
     #------------------------------------------------------
-    ##FOR DEBUG ONLYif ! release_version="$(_GetLatestFWUpdateVersionFromRouter_)" || \
-    ##FOR DEBUG ONLY   ! _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
-    ##FOR DEBUG ONLYthen
-    ##FOR DEBUG ONLY    Say "No new firmware version update is found for [$PRODUCT_ID] router model."
-    ##FOR DEBUG ONLY    "$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
-    ##FOR DEBUG ONLY    return 1
-    ##FOR DEBUG ONLYfi
+    if ! release_version="$(_GetLatestFWUpdateVersionFromRouter_)" || \
+       ! _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
+    then
+        Say "No new firmware version update is found for [$PRODUCT_ID] router model."
+        "$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
+        return 1
+    fi
 
     # Use set to read the output of the function into variables
     set -- $(_GetLatestFWUpdateVersionFromWebsite_ "$FW_URL_RELEASE")

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -2114,7 +2114,7 @@ show_menu()
    fi
    
    if ! _HasRouterMoreThan256MBtotalRAM_ && ! _ValidateUSBMountPoint_ "$FW_ZIP_BASE_DIR"; then
-      Say "${REDct}WARNING:${NOct} Limited RAM (256MB). 
+      Say "${REDct}WARNING:${NOct} Limited RAM detected (256MB). 
 A USB drive is required for F/W updates.\n"
    fi
 

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -8,7 +8,7 @@
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION="0.2.30"
+readonly SCRIPT_VERSION="0.2.27"
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -247,7 +247,8 @@ _CheckForNewScriptUpdates_()
    # Version comparison
    if [ "$DLRepoVersionNum" -gt "$ScriptVersionNum" ]
    then
-      UpdateNotify="New script update available: v$SCRIPT_VERSION -> v$DLRepoVersion"
+      UpdateNotify="New script update available: 
+${REDct}v$SCRIPT_VERSION${NOct} --> ${GRNct}v$DLRepoVersion${NOct}"
       Say "$(date +'%b %d %Y %X') $(nvram get lan_hostname) ${ScriptFNameTag}_[$$] - INFO: A new script update (v$DLRepoVersion) is available to download."
    else
       UpdateNotify=0
@@ -946,9 +947,9 @@ _GetCurrentFWInstalledShortVersion_()
 ##-------------------------------------##
 _HasRouterMoreThan256MBtotalRAM_()
 {
-   local totalRAM_KB
-   totalRAM_KB="$(cat /proc/meminfo | awk -F ' ' '/^MemTotal: /{print $2}')"
-   [ -n "$totalRAM_KB" ] && [ "$totalRAM_KB" -gt 262144 ] && return 0
+   #local totalRAM_KB
+   #totalRAM_KB="$(cat /proc/meminfo | awk -F ' ' '/^MemTotal: /{print $2}')"
+   #[ -n "$totalRAM_KB" ] && [ "$totalRAM_KB" -gt 262144 ] && return 0
    return 1
 }
 
@@ -1634,8 +1635,8 @@ _RunFirmwareUpdateNow_()
        ! _CreateDirectory_ "$FW_BIN_DIR" ; then return 1 ; fi
 
     # Get current firmware version #
-    current_version="$(_GetCurrentFWInstalledShortVersion_)"
-    ##FOR DEBUG ONLY##current_version="388.3.0"
+    ##FOR DEBUG ONLYcurrent_version="$(_GetCurrentFWInstalledShortVersion_)"
+    current_version="388.3.0"
 
     #---------------------------------------------------------#
     # If the "F/W Update Check" in the WebGUI is disabled 
@@ -1658,13 +1659,13 @@ _RunFirmwareUpdateNow_()
     # "New F/W Release Version" from the router itself.
     # If no new F/W version update is available exit.
     #------------------------------------------------------
-    if ! release_version="$(_GetLatestFWUpdateVersionFromRouter_)" || \
-       ! _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
-    then
-        Say "No new firmware version update is found for [$PRODUCT_ID] router model."
-        "$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
-        return 1
-    fi
+    ##FOR DEBUG ONLYif ! release_version="$(_GetLatestFWUpdateVersionFromRouter_)" || \
+    ##FOR DEBUG ONLY   ! _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
+    ##FOR DEBUG ONLYthen
+    ##FOR DEBUG ONLY    Say "No new firmware version update is found for [$PRODUCT_ID] router model."
+    ##FOR DEBUG ONLY    "$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
+    ##FOR DEBUG ONLY    return 1
+    ##FOR DEBUG ONLYfi
 
     # Use set to read the output of the function into variables
     set -- $(_GetLatestFWUpdateVersionFromWebsite_ "$FW_URL_RELEASE")
@@ -1796,7 +1797,8 @@ _RunFirmwareUpdateNow_()
 	if [ -n "$rog_file" ]; then
 		# If in interactive mode, prompt the user for their choice
 		if [ "$inMenuMode" = true ]; then
-			printf "${REDct}Found ROG build: $rog_file. Would you like to use the ROG build? (y/n)${NOct}\n"
+			printf "${REDct}Found ROG build: $rog_file. 
+Would you like to use the ROG build? (y/n)${NOct}\n"
 			read -rp "Enter your choice: " choice
 			if [ "$choice" = "y" ] || [ "$choice" = "Y" ]; then
 				firmware_file="$rog_file"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1706,6 +1706,13 @@ _RunFirmwareUpdateNow_()
 	##---------------------------------------##
 	# Get the required space for the firmware download and extraction
 	required_space_kb=$(get_required_space "$release_link")
+	if ! _HasRouterMoreThan256MBtotalRAM_ && [ "$required_space_kb" -gt 51200 ]; then
+		if ! _ValidateUSBMountPoint_ "$FW_ZIP_BASE_DIR"; then
+			Say "${REDct}**ERROR**${NOct}: A USB drive is required for the F/W update due to limited RAM."
+			"$inMenuMode" && _WaitForEnterKey_ "$menuReturnPromptStr"
+			return 1
+		fi
+	fi
 	availableRAM_kb=$(_GetAvailableRAM_KB_)
 	Say "Required RAM: ${required_space_kb}KB - Available RAM: ${availableRAM_kb}KB"
 	check_memory_and_prompt_reboot "$required_space_kb" "$availableRAM_kb"
@@ -2100,7 +2107,12 @@ show_menu()
 
    # New Script Update Notification #
    if [ "$UpdateNotify" != "0" ]; then
-      Say "${REDct}${UpdateNotify}${NOct}"
+      Say "${REDct}WARNING:${NOct} ${UpdateNotify}${NOct}\n"
+   fi
+   
+   if ! _HasRouterMoreThan256MBtotalRAM_ && ! _ValidateUSBMountPoint_ "$FW_ZIP_BASE_DIR"; then
+      Say "${REDct}WARNING:${NOct} Limited RAM (256MB). 
+A USB drive is required for F/W updates.\n"
    fi
 
    padStr="      "  arrowStr=" ${REDct}<<---${NOct}"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1692,9 +1692,6 @@ _RunFirmwareUpdateNow_()
         return 1
     fi
 
-    #BEGIN: Redirect both stdout and stderr to log file #
-    {
-
     if [ "$1" = "**ERROR**" ] && [ "$2" = "**NO_URL**" ] 
     then
         Say "${REDct}**ERROR**${NOct}: No firmware release URL was found for [$PRODUCT_ID] router model."
@@ -1714,6 +1711,10 @@ _RunFirmwareUpdateNow_()
 			return 1
 		fi
 	fi
+	
+	#BEGIN: Redirect both stdout and stderr to log file #
+    {
+	
 	availableRAM_kb=$(_GetAvailableRAM_KB_)
 	Say "Required RAM: ${required_space_kb}KB - Available RAM: ${availableRAM_kb}KB"
 	check_memory_and_prompt_reboot "$required_space_kb" "$availableRAM_kb"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2021-Nov-01
-# Last Modified: 2023-Dec-15
+# Last Modified: 2023-Dec-16
 ###################################################################
 set -u
 
@@ -226,8 +226,7 @@ readonly SETTINGSFILE="${SETTINGS_DIR}/custom_settings.txt"
 readonly SCRIPTVERPATH="${SETTINGS_DIR}/version.txt"
 
 ##-----------------------------------------------##
-## Original Author: ExtremeFiretop [2023-Nov-26] ##
-## Modified by: Martinski W. [2023-Dec-01]       ##
+## Modified by: ExtremeFiretop [2023-Dec-16]     ##
 ##-----------------------------------------------##
 _CheckForNewScriptUpdates_()
 {
@@ -247,7 +246,7 @@ _CheckForNewScriptUpdates_()
    # Version comparison
    if [ "$DLRepoVersionNum" -gt "$ScriptVersionNum" ]
    then
-      UpdateNotify="New script update available: 
+      UpdateNotify="New script update available.
 ${REDct}v$SCRIPT_VERSION${NOct} --> ${GRNct}v$DLRepoVersion${NOct}"
       Say "$(date +'%b %d %Y %X') $(nvram get lan_hostname) ${ScriptFNameTag}_[$$] - INFO: A new script update (v$DLRepoVersion) is available to download."
    else
@@ -256,7 +255,6 @@ ${REDct}v$SCRIPT_VERSION${NOct} --> ${GRNct}v$DLRepoVersion${NOct}"
 }
 
 ##-----------------------------------------------##
-## Original Author: ExtremeFiretop [2023-Nov-26] ##
 ## Modified by: Martinski W. [2023-Dec-01]       ##
 ##-----------------------------------------------##
 #a function that provides a UI to check for script updates and allows you to install the latest version...
@@ -1584,7 +1582,7 @@ _Toggle_FW_UpdateCheckSetting_()
 }
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2023-Dec-05] ##
+## Modified by ExtremeFiretop [2023-Dec-16] ##
 ##------------------------------------------##
 # Embed functions from second script, modified as necessary.
 _RunFirmwareUpdateNow_()
@@ -1740,7 +1738,7 @@ _RunFirmwareUpdateNow_()
     fi
 
 	##---------------------------------------##
-	## Added by ExtremeFiretop [2023-Dec-09] ##
+	## Added by ExtremeFiretop [2023-Dec-16] ##
 	##---------------------------------------##	
 	availableRAM_kb=$(_GetAvailableRAM_KB_)
 	Say "Required RAM: ${required_space_kb}KB - Available RAM: ${availableRAM_kb}KB"
@@ -2099,7 +2097,7 @@ FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
 FW_InstalledVersion="${GRNct}$(_GetCurrentFWInstalledLongVersion_)${NOct}"
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2023-Dec-10] ##
+## Modified by ExtremeFiretop [2023-Dec-16] ##
 ##------------------------------------------##
 show_menu()
 {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---WORK IN PROGRESS--- 
 - PREVIEW, NOT YET COMPLETE. PLEASE EXPECT BUGS.
 
-![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/5cffe7fa-4c35-4ddc-b413-924836979320)
+![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/3d3a0a27-4871-4ca6-be76-249b35b95899)
 
 ---TESTERS NEEDED!--- 
  - If you see your router listed as untested below, feel free to test and report any issues.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Blocked due to low RAM/ROM space and/or have not received updates in several yea
 - Only once it's been vetted through most routers.
 
 - Notes:
-  - Might need to add some "overhead" to the file size comparison to account for the "ZIP + F/W" files being on the "$HOME" directory at the same time, even if just temporarily.
   - New routers use UBIFS instead of JFFS2.
 
 ## Merlin(A)uto(U)pdate

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
----WORK IN PROGRESS--- 
+---WORK IN PROGRESS---
+
 ![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/3d3a0a27-4871-4ca6-be76-249b35b95899)
 
 ---TESTERS NEEDED!--- 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---WORK IN PROGRESS--- 
 - PREVIEW, NOT YET COMPLETE. PLEASE EXPECT BUGS.
 
-![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/e948e3c3-9068-41ab-b8dc-3678a6eb4a68)
+![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/5cffe7fa-4c35-4ddc-b413-924836979320)
 
 ---TESTERS NEEDED!--- 
  - If you see your router listed as untested below, feel free to test and report any issues.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 ---WORK IN PROGRESS--- 
-- PREVIEW, NOT YET COMPLETE. PLEASE EXPECT BUGS.
-
 ![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/3d3a0a27-4871-4ca6-be76-249b35b95899)
 
 ---TESTERS NEEDED!--- 


### PR DESCRIPTION
Added the discussed warnings both in the menu and the run script.

1. Integrate the RAM Check: 
Use the _HasRouterMoreThan256MBtotalRAM_() function to determine if the router has more than 256MB of total RAM. If it doesn't, and the ZIP file size is over 50MB, we should enforce the requirement of a USB-attached drive for storing the ZIP file.

2. Warning Message in Menu: 
Display a warning message in the main menu if the router has only 256MB of RAM and no USB drive is selected as the zip destination.