### PR TITLE
Update MerlinAU.sh

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -2092,7 +2092,7 @@ fi
 _CheckForNewScriptUpdates_
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Nov-19] ##
+## Modified by Martinski W. [2023-Dec-18] ##
 ##----------------------------------------##
 FW_UpdateCheckState="$(nvram get firmware_check_enable)"
 [ -z "$FW_UpdateCheckState" ] && FW_UpdateCheckState=0
@@ -2115,6 +2115,16 @@ then
         printf "Cron job '${GRNct}${CRON_JOB_TAG}${NOct}' already exists.\n"
     fi
     _AddCronJobRunScriptHook_
+
+    #-----------------------------------------------------------#
+    # Check if router reports a new F/W update is available.
+    # If yes, modify the notification settings accordingly.
+    #-----------------------------------------------------------#
+    current_version="$(_GetCurrentFWInstalledShortVersion_)"
+    release_version="$(_GetLatestFWUpdateVersionFromRouter_)"
+    [ -n "$current_version" ] && [ -n "$release_version" ] && \
+    _CheckNewUpdateFirmwareNotification_ "$current_version" "$release_version"
+
     _WaitForEnterKey_
 fi
 

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1593,7 +1593,7 @@ _Toggle_FW_UpdateCheckSetting_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Dec-17] ##
+## Modified by Martinski W. [2023-Dec-18] ##
 ##----------------------------------------##
 # Embed functions from second script, modified as necessary.
 _RunFirmwareUpdateNow_()
@@ -1856,6 +1856,12 @@ Would you like to use the ROG build? (y/n)${NOct}\n"
     printf "Once started, the flashing process CANNOT be interrupted.\n"
     if ! _WaitForYESorNO_ "Continue"
     then _DoCleanUp_ 1 "$keepZIPfile" ; return 1 ; fi
+
+    #------------------------------------------------------------#
+    # Restart the WebGUI to make sure nobody else is logged in
+    # so that the F/W Update can start without interruptions.
+    #------------------------------------------------------------#
+    /sbin/service restart_httpd && sleep 3
 
     curl_response="$(curl "${routerURLstr}/login.cgi" \
     --referer ${routerURLstr}/Main_Login.asp \


### PR DESCRIPTION
Added a background child process to simply wait for 6 minutes while the F/W Update is in progress. If after 6 minutes the curl process still exists, the background task kills it; otherwise, it does nothing & returns. This is our "escape hatch" to handle the rare possibility that the curl command never completes the F/W Update. OTOH, if the F/W update completes normally, the background task will simply do nothing and may get terminated if the router reboots itself. I believe 6 minutes should be plenty of time to complete any F/W update, but we can increase it if/when needed.