### PR TITLE
Update MerlinAU.sh Cron Handling and Min Warning Message

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1118,7 +1118,7 @@ get_required_space() {
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2023-Dec-26] ##
+## Modified by Martinski W. [2024-Jan-06] ##
 ##----------------------------------------##
 check_memory_and_prompt_reboot() {
     local required_space_kb="$1"
@@ -1987,7 +1987,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     fi
 
     ##------------------------------------------##
-    ## Modified by ExtremeFiretop [2023-Dec-26] ##
+    ## Modified by ExtremeFiretop [2024-Jan-06] ##
     ##------------------------------------------##
     availableRAM_kb=$(_GetAvailableRAM_KB_)
     Say "Required RAM: ${required_space_kb} KB - Available RAM: ${availableRAM_kb} KB"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1135,13 +1135,14 @@ check_memory_and_prompt_reboot() {
         availableRAM_kb=$(_GetAvailableRAM_KB_)
         if [ "$availableRAM_kb" -lt "$required_space_kb" ]; then
             # In an interactive shell session, ask user to confirm reboot #
-            if "$isInteractive" && _WaitForYESorNO_ "Reboot router now"
-            then
-                _AddPostRebootRunScriptHook_
-                Say "Rebooting router..."
-                _ReleaseLock_
-                /sbin/service reboot
-                exit 1  # Although the reboot command should end the script, it's good practice to exit after.
+            if [ "$inMenuMode" = true ]; then
+                if _WaitForYESorNO_ "Reboot router now"; then
+                    _AddPostRebootRunScriptHook_
+                    Say "Rebooting router..."
+                    _ReleaseLock_
+                    /sbin/service reboot
+                    exit 1  # Although the reboot command should end the script, it's good practice to exit after.
+                fi
             else
                 # Exit script if non-interactive or if user answers NO #
                 Say "Insufficient memory to continue. Exiting script."
@@ -1995,8 +1996,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     routerURLstr="$(_GetRouterURL_)"
     Say "Router Web URL is: ${routerURLstr}"
 
-    if "$isInteractive"
-    then
+    if [ "$inMenuMode" = true ]; then
         printf "${GRNct}**IMPORTANT**:${NOct}\nThe firmware flash is about to start.\n"
         printf "Press Enter to stop now, or type ${GRNct}Y${NOct} to continue.\n"
         printf "Once started, the flashing process CANNOT be interrupted.\n"


### PR DESCRIPTION
Hey @Martinski4GitHub 

Unfortunately the changes done in PR: https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/pull/60 broke something.
I did the changes for the warning to display the min version here: https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/commit/6c5045bcb7d1d3537fb297260f50af9bdcc51348
(It was a small change so I pushed it straight to dev). 

And then retested everything as a background cron job by downgrading to 388.4 and then setting up on a 5 minute cron cycle, it never actually updated again getting stuck at the same place as last time. 

Logs here for reference: 
[GT-AXE11000_FW_Update_2024-01-06_09_45_00.log](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/files/13850165/GT-AXE11000_FW_Update_2024-01-06_09_45_00.log)

I rolled back the changes done in PR: https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/pull/60

And everything works as a background cron job again.