### PR TITLE
Update MerlinAU.sh Unmount

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -2338,30 +2338,6 @@ _EntwareServicesHandler_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2024-Jan-29] ##
-##----------------------------------------##
-_UnmountUSBDrives_()
-{
-   local theDevice  mountPointRegExp="^/dev/sd[a-z][0-9]+.* /tmp/mnt/.*"
-
-   mountedDevices="$(grep -E "$mountPointRegExp" /proc/mounts | awk -F ' ' '{print $1}')"
-   [ -z "$mountedDevices" ] && return 1
-
-   "$isInteractive" && \
-   printf "\nUnmounting USB-attached drives. Please wait...\n"
-
-   # Stop existing apps & services that may be using the USB drive #
-   /sbin/service stop_samba >/dev/null 2>&1
-   /sbin/service stop_nasapps >/dev/null 2>&1
-   sleep 2
-
-   for theDevice in $mountedDevices
-   do umount -f "$theDevice" 2>/dev/null; sleep 2 ; done
-
-   printf "\nDone.\n"
-}
-
-##----------------------------------------##
 ## Modified by Martinski W. [2024-Jan-25] ##
 ##----------------------------------------##
 # Embed functions from second script, modified as necessary.
@@ -2832,7 +2808,7 @@ Please manually update to version $minimum_supported_version or higher to use th
         echo
 
         # *WARNING*: No more logging at this point & beyond #
-        _UnmountUSBDrives_
+        ejusb -1 0 -u 1
 
         #-------------------------------------------------------
         # Stop toggling LEDs during the F/W flash to avoid


### PR DESCRIPTION
Again same general improvement as last round.
This command just is simpler than the function.

1. The function displays no text to me and has not once, while trying to unmount the drive. 
(I would expect to see the printf "\nUnmounting USB-attached drives. Please wait...\n")
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/56fbe816-5431-40ed-8f7c-8bddd1638a69)


2. I am not a fan of how your function attempts to unmount my UBIFS (which stores my JFFs).
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/f736f504-c54b-4aee-bec8-1218931c9128)

3. Finally it never worked as pictured below:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/56fbe816-5431-40ed-8f7c-8bddd1638a69)

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/ec639499-e65f-462e-9164-e194bc538e24)


----Setup and tests-----
Cleanly formatted USB:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/483603cf-7786-4ec4-b7b2-278aa7d412ac)

Move the stop flash right after the unmount function.. To be able to test and catch the text or check the USB afterwards:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/fca5bd34-2738-4369-830d-2c5418cdb539)

No text is displayed and no USB is unmounted and this again is cleanly formatted not being used actively for any real purpose
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/7c840f92-9382-45be-b40c-5015b9cb84df)


In comparison the command provided instantly unmounted samba and the USB:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/55369efc-cebf-41e3-8df1-e7b65ced8629)
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/d2e45f44-58ef-423c-bf0a-bad24e9a470d)

