### PR TITLE
ROG Failure Email Patch

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,11 +4,11 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Feb-22
+# Last Modified: 2024-Feb-27
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION=1.0.5
+readonly SCRIPT_VERSION=1.0.6
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -1214,9 +1214,9 @@ _GetLatestFWUpdateVersionFromRouter_()
    echo "$newVersionStr" ; return "$retCode"
 }
 
-##----------------------------------------##
-## Modified by Martinski W. [2024-Feb-20] ##
-##----------------------------------------##
+##------------------------------------------##
+## Modified by ExtremeFiretop [2024-Feb-27] ##
+##------------------------------------------##
 _CreateEMailContent_()
 {
    if [ $# -eq 0 ] || [ -z "$1" ] ; then return 1 ; fi
@@ -1227,6 +1227,9 @@ _CreateEMailContent_()
    rm -f "$tempEMailContent" "$tempEMailBodyMsg"
 
    fwInstalledVersion="$(_GetCurrentFWInstalledLongVersion_)"
+   case "$fwInstalledVersion" in
+      *_rog) fwInstalledVersion=$(echo "$fwInstalledVersion" | sed 's/_rog$//') ;;
+   esac
    fwNewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
    subjectStr="F/W Update Status for $MODEL_ID"
 


### PR DESCRIPTION
Currently with ROG routers using ROG builds of the firmware, post reboot the email notifications function believes that the firmware update failed when in fact it did not.

User will receive a "failed update" email even though the router updated successfully on rog routers using rog UIs.
Seems I had an issue with the post-reboot hook since the update happened successfully and it waited 3 minutes to send me the notification. Something was evaluated wrong in the post reboot.

Post reboot file variables:
savedInstalledVersion = 3004.388.6.0_rog
savedNewUpdateVersion = 3004.388.6.2

$fwInstalledVersion:
Pre-Update = 3004.388.6.0_rog
Post-Update = 3004.388.6.2_rog

There's a potential issue in comparing version strings with and without suffixes (like _rog)?
If the script strictly compares these strings, 3004.388.6.2 would not be considered equal to 3004.388.6.2_rog, and thus, the post-update scenario might not be recognized as successful.