### PR TITLE
Disable Email Notifications for Available Updates from Node

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -3043,7 +3043,10 @@ _CheckNewUpdateFirmwareNotification_()
            fwNewUpdateNotificationDate="$(date +"$FW_UpdateNotificationDateFormat")"
            Update_Custom_Settings FW_New_Update_Notification_Vers "$fwNewUpdateNotificationVers"
            Update_Custom_Settings FW_New_Update_Notification_Date "$fwNewUpdateNotificationDate"
-           _SendEMailNotification_ NEW_FW_UPDATE_STATUS
+           if "$inRouterSWmode" 
+           then
+              _SendEMailNotification_ NEW_FW_UPDATE_STATUS
+           fi
        fi
    fi
 
@@ -3052,7 +3055,10 @@ _CheckNewUpdateFirmwareNotification_()
    then
        fwNewUpdateNotificationDate="$(date +"$FW_UpdateNotificationDateFormat")"
        Update_Custom_Settings FW_New_Update_Notification_Date "$fwNewUpdateNotificationDate"
-       _SendEMailNotification_ NEW_FW_UPDATE_STATUS
+       if "$inRouterSWmode" 
+       then
+          _SendEMailNotification_ NEW_FW_UPDATE_STATUS
+       fi
    fi
    return 0
 }

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -8,7 +8,7 @@
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION=1.1.0
+readonly SCRIPT_VERSION=1.1.1
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -3008,7 +3008,7 @@ _Set_FW_UpdateCronSchedule_()
 }
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Jan-26] ##
+## Modified by ExtremeFiretop [2024-Apr-13] ##
 ##------------------------------------------##
 _CheckNewUpdateFirmwareNotification_()
 {


### PR DESCRIPTION
Disable Email Notifications for Available Updates from Node
Primary now handles these updates notifications for the nodes.

Even if they want notifications enabled on the node for flashing, unzip errors, ect, they shouldn't be receiving the update available notifications.