### PR TITLE
Node_Logs_Patch

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4862,14 +4862,13 @@ _ShowNodesMenuOptions_()
 # Main Menu loop
 inMenuMode=true
 HIDE_ROUTER_SECTION=false
+if ! node_list="$(_GetNodeIPv4List_)"
+then node_list="" ; fi
 
 while true
 do
    # Check if the directory exists again before attempting to navigate to it
    [ -d "$FW_BIN_DIR" ] && cd "$FW_BIN_DIR"
-
-   if ! node_list="$(_GetNodeIPv4List_)"
-   then node_list="" ; fi
 
    _ShowMainMenu_
    printf "Enter selection:  " ; read -r userChoice


### PR DESCRIPTION
Quick fix to resolve the Node_Logs being populated multiple times everytime the user interacts with the main menu.
Tested with success, no need to remove the debug message itself from the _GetNodeIPv4List_ function.