### PR TITLE
Node_MinorLogicFix

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4162,6 +4162,24 @@ _SetEMailFormatType_()
    _WaitForEnterKey_ "$advnMenuReturnPromptStr"
 }
 
+# RegExp for IPv4 address #
+readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
+readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
+readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
+
+##----------------------------------------##
+## Modified by Martinski W. [2024-Apr-06] ##
+##----------------------------------------##
+_ValidatePrivateIPv4Address_()
+{
+   if [ $# -eq 0 ] || [ -z "$1" ] || \
+      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
+      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
+   then return 1
+   else return 0
+   fi
+}
+
 _ProcessMeshNodes_()
 {
     includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
@@ -4750,70 +4768,6 @@ _ShowAdvancedOptionsMenu_()
 
    printf "\n  ${GRNct}e${NOct}.  Return to Main Menu\n"
    printf "${SEPstr}"
-}
-
-# RegExp for IPv4 address #
-readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
-readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
-readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-Apr-06] ##
-##----------------------------------------##
-_ValidatePrivateIPv4Address_()
-{
-   if [ $# -eq 0 ] || [ -z "$1" ] || \
-      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
-      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
-   then return 1
-   else return 0
-   fi
-}
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-Apr-06] ##
-##----------------------------------------##
-_ProcessMeshNodes_()
-{
-    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
-    if [ $# -eq 0 ] || [ -z "$1" ]
-    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
-
-    uid=1
-    if ! node_list="$(_GetNodeIPv4List_)"
-    then node_list="" ; fi
-
-    if "$inRouterSWmode"
-    then
-        if [ -n "$node_list" ]
-        then
-            # Iterate over the list of nodes and print information for each node
-            for nodeIPv4addr in $node_list
-            do
-                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
-                _GetNodeInfo_ "$nodeIPv4addr"
-                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
-                then
-                    Node_FW_NewUpdateVersion="NONE FOUND"
-                else
-                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
-                fi
-
-                # Apply extra logic if flag is '1'
-                if [ "$includeExtraLogic" -eq 1 ]; then
-                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
-                    uid="$((uid + 1))"
-                fi
-            done
-            if [ -s "$tempNodeEMailList" ]; then
-                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
-            fi
-        else
-            if [ "$includeExtraLogic" -eq 1 ]; then
-                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
-            fi
-        fi
-    fi
 }
 
 ##---------------------------------------##

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,11 +4,11 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Apr-26
+# Last Modified: 2024-Apr-30
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION=1.1.2
+readonly SCRIPT_VERSION=1.1.3
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -4162,6 +4162,70 @@ _SetEMailFormatType_()
    _WaitForEnterKey_ "$advnMenuReturnPromptStr"
 }
 
+# RegExp for IPv4 address #
+readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
+readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
+readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
+
+##----------------------------------------##
+## Modified by Martinski W. [2024-Apr-06] ##
+##----------------------------------------##
+_ValidatePrivateIPv4Address_()
+{
+   if [ $# -eq 0 ] || [ -z "$1" ] || \
+      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
+      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
+   then return 1
+   else return 0
+   fi
+}
+
+##------------------------------------------##
+## Modified by ExtremeFiretop [2024-Apr-30] ##
+##------------------------------------------##
+_ProcessMeshNodes_()
+{
+    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
+
+    uid=1
+    if ! node_list="$(_GetNodeIPv4List_)"
+    then node_list="" ; fi
+
+    if "$inRouterSWmode"
+    then
+        if [ -n "$node_list" ]
+        then
+            # Iterate over the list of nodes and print information for each node
+            for nodeIPv4addr in $node_list
+            do
+                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
+                _GetNodeInfo_ "$nodeIPv4addr"
+                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
+                then
+                    Node_FW_NewUpdateVersion="NONE FOUND"
+                else
+                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
+                fi
+
+                # Apply extra logic if flag is '1'
+                if [ "$includeExtraLogic" -eq 1 ]; then
+                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
+                    uid="$((uid + 1))"
+                fi
+            done
+            if [ -s "$tempNodeEMailList" ]; then
+                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
+            fi
+        else
+            if [ "$includeExtraLogic" -eq 1 ]; then
+                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
+            fi
+        fi
+    fi
+}
+
 ##-------------------------------------##
 ## Added by Martinski W. [2024-Feb-16] ##
 ##-------------------------------------##
@@ -4709,73 +4773,6 @@ _ShowAdvancedOptionsMenu_()
    printf "${SEPstr}"
 }
 
-# RegExp for IPv4 address #
-readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
-readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
-readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-Apr-06] ##
-##----------------------------------------##
-_ValidatePrivateIPv4Address_()
-{
-   if [ $# -eq 0 ] || [ -z "$1" ] || \
-      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
-      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
-   then return 1
-   else return 0
-   fi
-}
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-Apr-06] ##
-##----------------------------------------##
-_ProcessMeshNodes_()
-{
-    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
-    if [ $# -eq 0 ] || [ -z "$1" ]
-    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
-
-    uid=1
-    if ! node_list="$(_GetNodeIPv4List_)"
-    then node_list="" ; fi
-
-    if ! node_online_status="$(_NodeActiveStatus_)"
-    then node_online_status="" ; fi
-
-    if "$inRouterSWmode"
-    then
-        if [ -n "$node_list" ]
-        then
-            # Iterate over the list of nodes and print information for each node
-            for nodeIPv4addr in $node_list
-            do
-                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
-                _GetNodeInfo_ "$nodeIPv4addr"
-                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
-                then
-                    Node_FW_NewUpdateVersion="NONE FOUND"
-                else
-                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
-                fi
-
-                # Apply extra logic if flag is '1'
-                if [ "$includeExtraLogic" -eq 1 ]; then
-                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
-                    uid="$((uid + 1))"
-                fi
-            done
-            if [ -s "$tempNodeEMailList" ]; then
-                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
-            fi
-        else
-            if [ "$includeExtraLogic" -eq 1 ]; then
-                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
-            fi
-        fi
-    fi
-}
-
 ##---------------------------------------##
 ## Added by ExtremeFiretop [2024-Apr-02] ##
 ##---------------------------------------##
@@ -4785,6 +4782,9 @@ _ShowNodesMenu_()
    logo
    printf "============== AiMesh Node(s) Info Menu ==============\n"
    printf "${SEPstr}\n"
+
+   if ! node_online_status="$(_NodeActiveStatus_)"
+   then node_online_status="" ; fi
 
    # Count the number of IP addresses
    local numIPs="$(echo "$node_list" | wc -w)"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -452,7 +452,7 @@ readonly WHITEct="\e[1;37m"
 ##----------------------------------------##
 ## Modified by Martinski W. [2024-Feb-22] ##
 ##----------------------------------------##
-readonly FW_Update_CRON_DefaultSchedule="0 0 * * Sun"
+readonly FW_Update_CRON_DefaultSchedule="0 0 * * *"
 
 readonly CRON_MINS_RegEx="([*0-9]|[1-5][0-9])([\/,-]([0-9]|[1-5][0-9]))*"
 readonly CRON_HOUR_RegEx="([*0-9]|1[0-9]|2[0-3])([\/,-]([0-9]|1[0-9]|2[0-3]))*"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4162,70 +4162,6 @@ _SetEMailFormatType_()
    _WaitForEnterKey_ "$advnMenuReturnPromptStr"
 }
 
-# RegExp for IPv4 address #
-readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
-readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
-readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-Apr-06] ##
-##----------------------------------------##
-_ValidatePrivateIPv4Address_()
-{
-   if [ $# -eq 0 ] || [ -z "$1" ] || \
-      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
-      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
-   then return 1
-   else return 0
-   fi
-}
-
-##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Apr-30] ##
-##------------------------------------------##
-_ProcessMeshNodes_()
-{
-    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
-    if [ $# -eq 0 ] || [ -z "$1" ]
-    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
-
-    uid=1
-    if ! node_list="$(_GetNodeIPv4List_)"
-    then node_list="" ; fi
-
-    if "$inRouterSWmode"
-    then
-        if [ -n "$node_list" ]
-        then
-            # Iterate over the list of nodes and print information for each node
-            for nodeIPv4addr in $node_list
-            do
-                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
-                _GetNodeInfo_ "$nodeIPv4addr"
-                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
-                then
-                    Node_FW_NewUpdateVersion="NONE FOUND"
-                else
-                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
-                fi
-
-                # Apply extra logic if flag is '1'
-                if [ "$includeExtraLogic" -eq 1 ]; then
-                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
-                    uid="$((uid + 1))"
-                fi
-            done
-            if [ -s "$tempNodeEMailList" ]; then
-                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
-            fi
-        else
-            if [ "$includeExtraLogic" -eq 1 ]; then
-                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
-            fi
-        fi
-    fi
-}
-
 ##-------------------------------------##
 ## Added by Martinski W. [2024-Feb-16] ##
 ##-------------------------------------##
@@ -4354,6 +4290,70 @@ _SetSecondaryEMailAddress_()
 
    _RunEMailNotificationTest_
    _WaitForEnterKey_ "$advnMenuReturnPromptStr"
+}
+
+# RegExp for IPv4 address #
+readonly IPv4octet_RegEx="([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-5][0-5])"
+readonly IPv4addrs_RegEx="((${IPv4octet_RegEx}\.){3}${IPv4octet_RegEx})"
+readonly IPv4privt_RegEx="((^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.))"
+
+##----------------------------------------##
+## Modified by Martinski W. [2024-Apr-06] ##
+##----------------------------------------##
+_ValidatePrivateIPv4Address_()
+{
+   if [ $# -eq 0 ] || [ -z "$1" ] || \
+      ! echo "$1" | grep -qE "^${IPv4addrs_RegEx}$" || \
+      ! echo "$1" | grep -qE "^${IPv4privt_RegEx}"
+   then return 1
+   else return 0
+   fi
+}
+
+##------------------------------------------##
+## Modified by ExtremeFiretop [2024-Apr-30] ##
+##------------------------------------------##
+_ProcessMeshNodes_()
+{
+    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
+    if [ $# -eq 0 ] || [ -z "$1" ]
+    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
+
+    uid=1
+    if ! node_list="$(_GetNodeIPv4List_)"
+    then node_list="" ; fi
+
+    if "$inRouterSWmode"
+    then
+        if [ -n "$node_list" ]
+        then
+            # Iterate over the list of nodes and print information for each node
+            for nodeIPv4addr in $node_list
+            do
+                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
+                _GetNodeInfo_ "$nodeIPv4addr"
+                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
+                then
+                    Node_FW_NewUpdateVersion="NONE FOUND"
+                else
+                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
+                fi
+
+                # Apply extra logic if flag is '1'
+                if [ "$includeExtraLogic" -eq 1 ]; then
+                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
+                    uid="$((uid + 1))"
+                fi
+            done
+            if [ -s "$tempNodeEMailList" ]; then
+                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
+            fi
+        else
+            if [ "$includeExtraLogic" -eq 1 ]; then
+                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
+            fi
+        fi
+    fi
 }
 
 keepZIPfile=0

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4740,6 +4740,9 @@ _ProcessMeshNodes_()
     if ! node_list="$(_GetNodeIPv4List_)"
     then node_list="" ; fi
 
+    if ! node_online_status="$(_NodeActiveStatus_)"
+    then node_online_status="" ; fi
+
     if "$inRouterSWmode"
     then
         if [ -n "$node_list" ]
@@ -4782,9 +4785,6 @@ _ShowNodesMenu_()
    logo
    printf "============== AiMesh Node(s) Info Menu ==============\n"
    printf "${SEPstr}\n"
-
-   if ! node_online_status="$(_NodeActiveStatus_)"
-   then node_online_status="" ; fi
 
    # Count the number of IP addresses
    local numIPs="$(echo "$node_list" | wc -w)"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4162,49 +4162,6 @@ _SetEMailFormatType_()
    _WaitForEnterKey_ "$advnMenuReturnPromptStr"
 }
 
-_ProcessMeshNodes_()
-{
-    includeExtraLogic="$1"  # Use '1' to include extra logic, '0' to exclude
-    if [ $# -eq 0 ] || [ -z "$1" ]
-    then echo "**ERROR** **NO_PARAMS**" ; return 1 ; fi
-
-    uid=1
-    if ! node_list="$(_GetNodeIPv4List_)"
-    then node_list="" ; fi
-
-    if "$inRouterSWmode"
-    then
-        if [ -n "$node_list" ]
-        then
-            # Iterate over the list of nodes and print information for each node
-            for nodeIPv4addr in $node_list
-            do
-                ! _ValidatePrivateIPv4Address_ "$nodeIPv4addr" && continue
-                _GetNodeInfo_ "$nodeIPv4addr"
-                if ! Node_FW_NewUpdateVersion="$(_GetLatestFWUpdateVersionFromNode_ 1)"
-                then
-                    Node_FW_NewUpdateVersion="NONE FOUND"
-                else
-                    _CheckNodeFWUpdateNotification_ "$Node_combinedVer" "$Node_FW_NewUpdateVersion"
-                fi
-
-                # Apply extra logic if flag is '1'
-                if [ "$includeExtraLogic" -eq 1 ]; then
-                    _PrintNodeInfo "$nodeIPv4addr" "$node_online_status" "$Node_FW_NewUpdateVersion" "$uid"
-                    uid="$((uid + 1))"
-                fi
-            done
-            if [ -s "$tempNodeEMailList" ]; then
-                _SendEMailNotification_ AGGREGATED_UPDATE_NOTIFICATION
-            fi
-        else
-            if [ "$includeExtraLogic" -eq 1 ]; then
-                printf "\n${padStr}${padStr}${padStr}${REDct}No AiMesh Node(s)${NOct}"
-            fi
-        fi
-    fi
-}
-
 ##-------------------------------------##
 ## Added by Martinski W. [2024-Feb-16] ##
 ##-------------------------------------##
@@ -4782,6 +4739,9 @@ _ProcessMeshNodes_()
     uid=1
     if ! node_list="$(_GetNodeIPv4List_)"
     then node_list="" ; fi
+
+    if ! node_online_status="$(_NodeActiveStatus_)"
+    then node_online_status="" ; fi
 
     if "$inRouterSWmode"
     then


### PR DESCRIPTION
Node_MinorLogicFix

As mentioned in PR: 197 here: https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/pull/197/files/d2f86af7c833992d0593a1a51166c95c2d203150

So about the frozen cron I wanted to discuss with you.
Originally, I didn't understand why moving the code from the email function resolved the issue.

All that made sense to me is somehow something wasn't being run/processed/populated when run as a cron job. Now going back through the code, I notice that:

`node_online_status=$(_NodeActiveStatus_)`

Is only located under the: `_ShowNodesMenu_` code.
But it looks like required code for the `_ProcessMeshNodes_` to run.

I'm assuming something like this is causing us our issues.
Any recommendations on where to move it? I'm thinking right below the:

`if ! node_list="$(_GetNodeIPv4List_)" then node_list="" ; fi`

of the `_ProcessMeshNodes_` function.