### PR TITLE
Changes to support new "3006.102.X" F/W versions

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-May-31
+# Last Modified: 2024-Jun-01
 ###################################################################
 set -u
 
@@ -236,7 +236,7 @@ _DoExit_()
 ## Modified by Martinski W. [2024-May-31] ##
 ##----------------------------------------##
 ## To support new "3006" F/W Basecode ##
-if [ "$fwInstalledBaseVers" -eq 3006 ]
+if [ "$fwInstalledBaseVers" -ge 3006 ]
 then readonly nvramLEDsVar=AllLED
 else readonly nvramLEDsVar=led_disable
 fi
@@ -1716,26 +1716,6 @@ if false ; then echo "3004.388.6.2" ; return 0 ; fi
    theVersionStr="${fwInstalledBaseVers}.${theVersionStr}"
 
    echo "$theVersionStr"
-}
-
-##----------------------------------------##
-## Modified by Martinski W. [2024-May-31] ##
-##----------------------------------------##
-_GetCurrentFWInstalledShortVersion_()
-{
-
-##FOR TESTING/DEBUG ONLY##
-if false ; then echo "388.6.2" ; return 0 ; fi
-##FOR TESTING/DEBUG ONLY##
-
-    local theVersionStr  extVersNum
-
-    extVersNum="$(echo "$fwInstalledExtendNum" | awk -F '-' '{print $1}')"
-    echo "$extVersNum" | grep -qiE "^(alpha|beta)" && extVersNum="0_$extVersNum"
-    [ -z "$extVersNum" ] && extVersNum=0
-
-    theVersionStr="${fwInstalledBuildVers}.$extVersNum"
-    echo "$theVersionStr"
 }
 
 ##----------------------------------------##


### PR DESCRIPTION
Some initial changes to support upcoming "3006.102.X" F/W versions.

1) Modified code to use the corresponding NVRAM variable: "**led_disable**" (old F/W) or "**AllLED**" (new F/W).

2) Modified code to get the corresponding filename & URL for the F/W Changelog.

3) Modified code to always get the long F/W version string so that we make correct numerical comparisons between "**3004.388**.X.Y" & "**3006.102**.X.Y" versions.

4) Code improvements to minimize some calls to NVRAM.

5) Fixed bug when "F/W Changelog Check Approval" did not always change the setting to BLOCK the firmware update.