### PR TITLE
Changes to support "3006.102.X" ROG Patch

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1151,7 +1151,8 @@ _Init_Custom_Settings_Config_
 # ROG upgrades to 3006 codebase should have 
 # the ROG option deleted.
 #-----------------------------------------------------------
-if [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"; then
+if [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"
+then
     Delete_Custom_Settings "ROGBuild"
 fi
 

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -5836,6 +5836,7 @@ _advanced_options_menu_()
                else
                    _InvalidMenuSelection_
                fi
+               ;;
            em) if "$isEMailConfigEnabledInAMTM"
                then _Toggle_FW_UpdateEmailNotifications_
                else _InvalidMenuSelection_


### PR DESCRIPTION
@Martinski4GitHub 

As per RMerlin here: https://www.snbforums.com/threads/announcement-asuswrt-merlin-support-underway-for-3-wifi-7-routers.90126/post-909548

ROG UI will no longer be supported in version 3006.
Due to this, I have made some logical changes to the update flow for ROG options.

This now includes a flow for updates with 3004 and below (WITH ROG Options)
Also an update flow for 3004 to 3006 (With and without ROG)
And an update flow for 3006 and above (Without ROG)