### PR TITLE
Update Curl to WGET

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -534,13 +534,18 @@ _CheckForNewScriptUpdates_()
    rm -f "$SCRIPTVERPATH"
 
    # Download the latest version file from the source repository
-   curl -LSs --retry 4 --retry-delay 5 "${SCRIPT_URL_BASE}/version.txt" -o "$SCRIPTVERPATH"
+   wget --quiet --tries=4 --waitretry=5 "${SCRIPT_URL_BASE}/version.txt" -O "$SCRIPTVERPATH"
 
    if [ $? -ne 0 ] || [ ! -s "$SCRIPTVERPATH" ]
    then scriptUpdateNotify=0 ; return 1 ; fi
 
    # Read in its contents for the current version file
    DLRepoVersion="$(cat "$SCRIPTVERPATH")"
+   if [ -z "$DLRepoVersion" ]; then
+       echo "Variable for downloaded version is empty."
+       UpdateNotify=0
+       return 1
+   fi
 
    DLRepoVersionNum="$(_ScriptVersionStrToNum_ "$DLRepoVersion")"
    ScriptVersionNum="$(_ScriptVersionStrToNum_ "$SCRIPT_VERSION")"
@@ -582,8 +587,8 @@ _SCRIPTUPDATE_()
       then
           echo ; echo
           echo -e "${CYANct}Downloading $SCRIPT_NAME ${CYANct}v$DLRepoVersion${NOct}"
-          curl -LSs --retry 4 --retry-delay 5 "${SCRIPT_URL_BASE}/version.txt" -o "$SCRIPTVERPATH"
-          curl -LSs --retry 4 --retry-delay 5 "${SCRIPT_URL_BASE}/${SCRIPT_NAME}.sh" -o "$ScriptFileDL"
+          wget --quiet --tries=4 --waitretry=5 "${SCRIPT_URL_BASE}/version.txt" -O "$SCRIPTVERPATH"
+          wget --quiet --tries=4 --waitretry=5 "${SCRIPT_URL_BASE}/${SCRIPT_NAME}.sh" -O "$ScriptFileDL"
 
           if [ $? -eq 0 ] && [ -s "$ScriptFileDL" ]
           then
@@ -613,8 +618,8 @@ _SCRIPTUPDATE_()
       then
           echo ; echo
           echo -e "${CYANct}Downloading $SCRIPT_NAME ${CYANct}v$DLRepoVersion${NOct}"
-          curl -LSs --retry 4 --retry-delay 5 "${SCRIPT_URL_BASE}/version.txt" -o "$SCRIPTVERPATH"
-          curl -LSs --retry 4 --retry-delay 5 "${SCRIPT_URL_BASE}/${SCRIPT_NAME}.sh" -o "$ScriptFileDL"
+          wget --quiet --tries=4 --waitretry=5 "${SCRIPT_URL_BASE}/version.txt" -O "$SCRIPTVERPATH"
+          wget --quiet --tries=4 --waitretry=5 "${SCRIPT_URL_BASE}/${SCRIPT_NAME}.sh" -O "$ScriptFileDL"
 
           if [ $? -eq 0 ] && [ -s "$ScriptFileDL" ]
           then
@@ -1594,7 +1599,7 @@ _SendEMailNotification_()
 
    date +"$LOGdateFormat" > "$userTraceFile"
 
-   /usr/sbin/curl -Lv --retry 4 --retry-delay 5 --url "${PROTOCOL}://${SMTP}:${PORT}" \
+   curl -Lv --retry 4 --retry-delay 5 --url "${PROTOCOL}://${SMTP}:${PORT}" \
    --mail-from "$FROM_ADDRESS" --mail-rcpt "$TO_ADDRESS" $CC_ADDRESS_ARG \
    --user "${USERNAME}:$(/usr/sbin/openssl aes-256-cbc "$emailPwEnc" -d -in "$amtmMailPswdFile" -pass pass:ditbabot,isoi)" \
    --upload-file "$tempEMailContent" \


### PR DESCRIPTION
wget's major strong side compared to curl is its ability to download recursively. (Curl cannot)
wget is command line only. There's no lib or anything, but curl's features are powered by libcurl.
curl offers upload and sending capabilities which is the main difference between curl and wget...
wget is only used to download things, while curl is used to test communication by using a specific protocol, etc.

This actually lines up with what we use in the Gnuton branch to interact with Github if you hadn't already noticed.
The standard in the script I was going for seems to be to use curl when we need to simulate a browser and need advanced "browser" features to "test" things. But that's up to discussion.

And wget is used just to grab/download files from Github. Thoughts?
This discussion will also determine what I do about all the wgets in the Gnuton branch, which does not exist in the standard branch (all curls in production).

I recommend you take a quick look that the solution there for grabbing the TUF UIs from Github.
Let me know your 2 cent's. I'm looking forwards :)