### PR TITLE
Fix Changelog Check Behavior

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Jun-16
+# Last Modified: 2024-Jun-24
 ###################################################################
 set -u
 
@@ -93,6 +93,7 @@ fi
 ##----------------------------------------##
 inMenuMode=true
 isInteractive=false
+FlashStarted=false
 
 readonly mainLAN_IPaddr="$(nvram get lan_ipaddr)"
 readonly fwInstalledBaseVers="$(nvram get firmver | sed 's/\.//g')"
@@ -1173,7 +1174,8 @@ _Init_Custom_Settings_Config_
 # ROG upgrades to 3006 codebase should have 
 # the ROG option deleted.
 #-----------------------------------------------------------
-if [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"
+if { [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"; } || 
+   { [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 > $2)}')" -eq 1 ] && grep -q "^ROGBuild" "$SETTINGSFILE"; }
 then
     Delete_Custom_Settings "ROGBuild"
 fi
@@ -1753,7 +1755,7 @@ _GetCurrentFWInstalledLongVersion_()
 {
 
 ##FOR TESTING/DEBUG ONLY##
-if false ; then echo "3004.388.6.2" ; return 0 ; fi
+if true ; then echo "3004.388.6.2" ; return 0 ; fi
 ##FOR TESTING/DEBUG ONLY##
 
    local theVersionStr  extVersNum
@@ -3815,7 +3817,10 @@ _CheckNewUpdateFirmwareNotification_()
            then
               _SendEMailNotification_ NEW_FW_UPDATE_STATUS
            fi
-           _ManageChangelog_ "download" "$fwNewUpdateNotificationVers"
+           if ! "$FlashStarted"
+           then
+              _ManageChangelog_ "download" "$fwNewUpdateNotificationVers"
+           fi
        fi
    fi
 
@@ -3828,7 +3833,10 @@ _CheckNewUpdateFirmwareNotification_()
        then
           _SendEMailNotification_ NEW_FW_UPDATE_STATUS
        fi
-       _ManageChangelog_ "download" "$fwNewUpdateNotificationVers"
+       if ! "$FlashStarted"
+       then
+          _ManageChangelog_ "download" "$fwNewUpdateNotificationVers"
+       fi
    fi
 
    fwNewUpdateNotificationDate="$(Get_Custom_Setting FW_New_Update_Notification_Date)"
@@ -4141,6 +4149,7 @@ Please manually update to version $minimum_supported_version or higher to use th
 
     Say "${GRNct}MerlinAU${NOct} v$SCRIPT_VERSION"
     Say "Running the update task now... Checking for F/W updates..."
+    FlashStarted=true
 
     #---------------------------------------------------------------#
     # Check if an expected USB-attached drive is still mounted.
@@ -4457,7 +4466,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     ##----------------------------------------##
     pure_file="$(ls -1 | grep -iE '.*[.](w|pkgtb)$' | grep -iv 'rog')"
 
-    if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$fwUpdateBaseNum" -le 3004 ]
+    if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$fwUpdateBaseNum" -le 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
     then
         # Handle upgrades from 3004 and lower #
 
@@ -4505,7 +4514,8 @@ Please manually update to version $minimum_supported_version or higher to use th
             Say "No ROG Build detected. Skipping."
             firmware_file="$pure_file"
         fi
-    elif [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$fwUpdateBaseNum" -ge 3006 ]
+    elif [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$fwUpdateBaseNum" -ge 3006 ] ||
+         [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 > $2)}')" -eq 1 ]
     then
         # Handle upgrade from 3004 to 3006
         # Fetch the previous choice from the settings file
@@ -4514,7 +4524,7 @@ Please manually update to version $minimum_supported_version or higher to use th
         # Handle upgrade from 3004 to 3006 if there is a ROG setting
         if [ "$previous_choice" = "y" ]
         then
-            Say "Upgrading from 3004 to 3006, ROG UI is no longer supported, auto-selecting Pure UI firmware."
+            Say "Upgrading from previous release to next release, ROG UI is no longer supported, auto-selecting Pure UI firmware."
             firmware_file="$pure_file"
             Update_Custom_Settings "ROGBuild" "n"
         else
@@ -5675,7 +5685,7 @@ _ShowAdvancedOptionsMenu_()
        fi
    fi
 
-   if [ "$fwInstalledBaseVers" -le 3004 ]
+   if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
    then
       # Retrieve the current build type setting
       local current_build_type="$(Get_Custom_Setting "ROGBuild")"
@@ -5866,7 +5876,8 @@ _advanced_options_menu_()
                fi
                ;;
            bt) if [ "$fwInstalledBaseVers" -le 3004 ] && \
-                  echo "$PRODUCT_ID" | grep -q "^GT-"
+                  echo "$PRODUCT_ID" | grep -q "^GT-" && \
+                  [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
                then change_build_type
                else _InvalidMenuSelection_
                fi

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1174,8 +1174,7 @@ _Init_Custom_Settings_Config_
 # ROG upgrades to 3006 codebase should have 
 # the ROG option deleted.
 #-----------------------------------------------------------
-if { [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"; } || 
-   { [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 > $2)}')" -eq 1 ] && grep -q "^ROGBuild" "$SETTINGSFILE"; }
+if [ "$fwInstalledBaseVers" -ge 3006 ] && grep -q "^ROGBuild" "$SETTINGSFILE"
 then
     Delete_Custom_Settings "ROGBuild"
 fi
@@ -1755,7 +1754,7 @@ _GetCurrentFWInstalledLongVersion_()
 {
 
 ##FOR TESTING/DEBUG ONLY##
-if true ; then echo "3004.388.6.2" ; return 0 ; fi
+if false ; then echo "3004.388.6.2" ; return 0 ; fi
 ##FOR TESTING/DEBUG ONLY##
 
    local theVersionStr  extVersNum
@@ -4466,7 +4465,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     ##----------------------------------------##
     pure_file="$(ls -1 | grep -iE '.*[.](w|pkgtb)$' | grep -iv 'rog')"
 
-    if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$fwUpdateBaseNum" -le 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
+    if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$fwUpdateBaseNum" -le 3004 ]
     then
         # Handle upgrades from 3004 and lower #
 
@@ -4514,8 +4513,7 @@ Please manually update to version $minimum_supported_version or higher to use th
             Say "No ROG Build detected. Skipping."
             firmware_file="$pure_file"
         fi
-    elif [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$fwUpdateBaseNum" -ge 3006 ] ||
-         [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 > $2)}')" -eq 1 ]
+    elif [ "$fwInstalledBaseVers" -eq 3004 ] && [ "$fwUpdateBaseNum" -ge 3006 ]
     then
         # Handle upgrade from 3004 to 3006
         # Fetch the previous choice from the settings file
@@ -4524,7 +4522,7 @@ Please manually update to version $minimum_supported_version or higher to use th
         # Handle upgrade from 3004 to 3006 if there is a ROG setting
         if [ "$previous_choice" = "y" ]
         then
-            Say "Upgrading from previous release to next release, ROG UI is no longer supported, auto-selecting Pure UI firmware."
+            Say "Upgrading from 3004 to 3006, ROG UI is no longer supported, auto-selecting Pure UI firmware."
             firmware_file="$pure_file"
             Update_Custom_Settings "ROGBuild" "n"
         else
@@ -5685,7 +5683,7 @@ _ShowAdvancedOptionsMenu_()
        fi
    fi
 
-   if [ "$fwInstalledBaseVers" -le 3004 ] && [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
+   if [ "$fwInstalledBaseVers" -le 3004 ]
    then
       # Retrieve the current build type setting
       local current_build_type="$(Get_Custom_Setting "ROGBuild")"
@@ -5876,8 +5874,7 @@ _advanced_options_menu_()
                fi
                ;;
            bt) if [ "$fwInstalledBaseVers" -le 3004 ] && \
-                  echo "$PRODUCT_ID" | grep -q "^GT-" && \
-                  [ "$(echo "$fwInstalledBaseVers 388.8" | awk '{print ($1 < $2)}')" -eq 1 ]
+                  echo "$PRODUCT_ID" | grep -q "^GT-"
                then change_build_type
                else _InvalidMenuSelection_
                fi


### PR DESCRIPTION
Fix Changelog Check Behavior.

As identified in the Gnuton branch, this shouldn't be happening, this PR/change continues to allow everything to function correctly when the cron detects an update or when an interactive session detects an update. 

But will limit it from running when an update was detected while MerlinAU was already running at the interactive screen.
While this is unlikely to happen to a user, since I can only make it happen when manually running: `nvram set webs_state_flag=1 ` it will make the debugging scenarios run as expected and limit unintended behavior.

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/8d844b81-6908-40b0-ac33-05d4202ec23b)