### PR TITLE
Fix Checksum Verification

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,11 +4,11 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Jun-28
+# Last Modified: 2024-Jun-30
 ###################################################################
 set -u
 
-readonly SCRIPT_VERSION=1.2.4
+readonly SCRIPT_VERSION=1.2.5
 readonly SCRIPT_NAME="MerlinAU"
 
 ##-------------------------------------##
@@ -1762,7 +1762,7 @@ _GetCurrentFWInstalledLongVersion_()
 {
 
 ##FOR TESTING/DEBUG ONLY##
-if false ; then echo "3004.388.6.2" ; return 0 ; fi
+if true ; then echo "3004.388.6.2" ; return 0 ; fi
 ##FOR TESTING/DEBUG ONLY##
 
    local theVersionStr  extVersNum
@@ -2618,7 +2618,7 @@ _Toggle_VPN_Access_()
     if [ "$currentSetting" = "ENABLED" ]
     then
         printf "${REDct}*WARNING*${NOct}\n"
-        printf "Disabling this feature will shut down Diversion and Tailscale VPN access during updates.\n"
+        printf "Disabling this feature will shut down Tailscale VPN access during updates.\n"
         printf "Proceed only if you do not need VPN access during updates.\n"
 
         if _WaitForYESorNO_ "\nProceed to ${GRNct}DISABLE${NOct}?"
@@ -2630,7 +2630,7 @@ _Toggle_VPN_Access_()
         fi
     else
         printf "${REDct}*WARNING*${NOct}\n"
-        printf "Enabling this feature will keep Diversion and Tailscale VPN access active during updates.\n"
+        printf "Enabling this feature will keep Tailscale VPN access active during updates.\n"
         printf "Proceed only if you need VPN access during updates.\n"
         if _WaitForYESorNO_ "\nProceed to ${REDct}ENABLE${NOct}?"
         then
@@ -4377,7 +4377,7 @@ Please manually update to version $minimum_supported_version or higher to use th
             if [ "$current_backup_settings" = "ENABLED" ]
             then
                 # Extract version number from backupmon.sh
-                BM_VERSION="$(grep "^Version=" /jffs/scripts/backupmon.sh | awk -F'"' '{print $2}')"
+                local BM_VERSION="$(grep "^Version=" /jffs/scripts/backupmon.sh | awk -F'"' '{print $2}')"
 
                 # Adjust version format from 1.46 to 1.4.6 if needed
                 DOT_COUNT="$(echo "$BM_VERSION" | tr -cd '.' | wc -c)"
@@ -4624,7 +4624,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     ## Modified by Martinski W. [2024-Jun-05] ##
     ##----------------------------------------##
     # Fetch the latest SHA256 checksums from ASUSWRT-Merlin website #
-    checksums="$(curl -Ls --retry 4 --retry-delay 5 https://www.asuswrt-merlin.net/download | sed -n '/<pre>/,/</pre>/p' | sed -e 's/<[^>]*>//g')"
+    checksums="$(curl -Ls --retry 4 --retry-delay 5 https://www.asuswrt-merlin.net/download | sed -n '/<pre[^>]*>/,/<\/pre>/p' | sed -e 's/<[^>]*>//g')"
 
     if [ -z "$checksums" ]
     then
@@ -4711,7 +4711,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     _EntwareServicesHandler_ stop
 
     ##------------------------------------------##
-    ## Modified by ExtremeFiretop [2024-Mar-15] ##
+    ## Modified by ExtremeFiretop [2024-Jun-30] ##
     ##------------------------------------------##
 
     curl_response="$(curl -k "${routerURLstr}/login.cgi" \
@@ -4735,17 +4735,48 @@ Please manually update to version $minimum_supported_version or higher to use th
         Say "Flashing ${GRNct}${firmware_file}${NOct}... ${REDct}Please wait for reboot in about 4 minutes or less.${NOct}"
         echo
 
-        local AllowVPN="$(Get_Custom_Setting Allow_Updates_OverVPN)"
-        if [ "$AllowVPN" = "DISABLED" ]
+        if [ -f /opt/bin/diversion ]
         then
-           if [ -f /opt/bin/diversion ]
-           then
-               # Diversion unmount command also unloads entware services #
-               Say "Stopping Diversion service..."
-               /opt/bin/diversion unmount &
-               sleep 5
-           fi
+            # Extract version number from Diversion
+            local DIVER_VERSION="$(grep "^VERSION=" /opt/bin/diversion | awk -F'=' '{print $2}' | tr -d ' ')"
+
+            # Adjust version format from 1.46 to 1.4.6 if needed
+            DDOT_COUNT="$(echo "$DIVER_VERSION" | tr -cd '.' | wc -c)"
+            if [ "$DDOT_COUNT" -eq 0 ]; then
+                # If there's no dot, it's a simple version like "1" (unlikely but let's handle it)
+                DIVER_VERSION="${DIVER_VERSION}.0.0"
+            elif [ "$DDOT_COUNT" -eq 1 ]; then
+                # Check if there is only one character after the dot
+                if echo "$DIVER_VERSION" | grep -qE '^[0-9]+\.[0-9]{1}$'; then
+                    # If the version is like 5.2, convert it to 5.2.0
+                    DIVER_VERSION="${DIVER_VERSION}.0"
+                else
+                    # For versions like 5.26, insert a dot between the last two digits
+                    DIVER_VERSION="$(echo "$DIVER_VERSION" | sed 's/\.\([0-9]\)\([0-9]\)/.\1.\2/')"
+                fi
+            fi
+
+            # Convert version strings to comparable numbers
+            local currentDIVER_version="$(_ScriptVersionStrToNum_ "$DIVER_VERSION")"
+            local requiredDIVER_version="$(_ScriptVersionStrToNum_ "5.2.0")"
+
+            # Diversion unmount command also unloads entware services #
+            Say "Stopping Diversion service..."
+            if [ "$currentDIVER_version" -ge "$requiredDIVER_version" ]
+            then
+                /opt/bin/diversion temp_disable &
+            else
+                local AllowVPN="$(Get_Custom_Setting Allow_Updates_OverVPN)"
+                if [ "$AllowVPN" = "DISABLED" ]
+                then
+                    /opt/bin/diversion unmount &
+                fi
+            fi
+            sleep 5
         fi
+
+        _DoExit_ 1
+        return 1
 
         # *WARNING*: No more logging at this point & beyond #
         /sbin/ejusb -1 0 -u 1
@@ -4804,7 +4835,21 @@ Please manually update to version $minimum_supported_version or higher to use th
         _SendEMailNotification_ FAILED_FW_UPDATE_STATUS
         _DoCleanUp_ 1 "$keepZIPfile"
         _EntwareServicesHandler_ start
-        # /opt/bin/diversion mount >/dev/null #Does not work temporarily
+        if [ -f /opt/bin/diversion ]
+        then
+            Say "Restarting Diversion service..."
+            if [ "$currentDIVER_version" -ge "$requiredDIVER_version" ]
+            then
+                /opt/bin/diversion enable &
+            else
+                AllowVPN="$(Get_Custom_Setting Allow_Updates_OverVPN)"
+                if [ "$AllowVPN" = "DISABLED" ]
+                then
+                    Say "Unable to Restart Diversion. Please reboot to restart entware services."
+                fi
+            fi
+            sleep 5
+        fi
     fi
 
     "$inMenuMode" && _WaitForEnterKey_ "$mainMenuReturnPromptStr"
@@ -5771,7 +5816,7 @@ _ShowAdvancedOptionsMenu_()
    fi
 
    local VPNAccess="$(Get_Custom_Setting "Allow_Updates_OverVPN")"
-   printf "\n  ${GRNct}4${NOct}.  Toggle Tailscale During Updates"
+   printf "\n  ${GRNct}4${NOct}.  Toggle Tailscale Access During Updates"
    if [ "$VPNAccess" = "DISABLED" ]
    then
        printf "\n${padStr}[Currently ${GRNct}DISABLED${NOct}]\n"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1762,7 +1762,7 @@ _GetCurrentFWInstalledLongVersion_()
 {
 
 ##FOR TESTING/DEBUG ONLY##
-if true ; then echo "3004.388.6.2" ; return 0 ; fi
+if false ; then echo "3004.388.6.2" ; return 0 ; fi
 ##FOR TESTING/DEBUG ONLY##
 
    local theVersionStr  extVersNum
@@ -4774,9 +4774,6 @@ Please manually update to version $minimum_supported_version or higher to use th
             fi
             sleep 5
         fi
-
-        _DoExit_ 1
-        return 1
 
         # *WARNING*: No more logging at this point & beyond #
         /sbin/ejusb -1 0 -u 1

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4624,7 +4624,7 @@ Please manually update to version $minimum_supported_version or higher to use th
     ## Modified by Martinski W. [2024-Jun-05] ##
     ##----------------------------------------##
     # Fetch the latest SHA256 checksums from ASUSWRT-Merlin website #
-    checksums="$(curl -Ls --retry 4 --retry-delay 5 https://www.asuswrt-merlin.net/download | sed -n '/<pre[^>]*>/,/<\/pre>/p' | sed -e 's/<[^>]*>//g')"
+    checksums="$(curl -Ls --retry 4 --retry-delay 5 https://www.asuswrt-merlin.net/download | sed -n '/<p><strong>SHA256 signatures:<\/strong><\/p>/,/<\/pre>/p' | sed -n '/<pre[^>]*>/,/<\/pre>/p' | sed -e 's/<[^>]*>//g' | sed '1d')"
 
     if [ -z "$checksums" ]
     then


### PR DESCRIPTION
Fix Checksum Verification:

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/4e04a7f9-4c6c-41cf-854e-bbeda3724262)

While testing my last PR, I came across this issue above.
Seems like some formatting to merlins website was changed/updated and the checksum verification now fails.
(On closer review, it looks like he added a new table for: **"No longer supported"**)

This PR includes updates to the checksum line to make it pass.
Previous solution:

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/438360d5-cf67-46cf-9e4b-1ff31531b0e8)

```
Admin@GT-BE98_Pro-DE30:/tmp/home/root# checksums="$(curl -Ls --retry 4 --retry-d
elay 5 https://www.asuswrt-merlin.net/download | sed -n '/<pre>/,/</pre>/p' | se
d -e 's/<[^>]*>//g')"
Admin@GT-BE98_Pro-DE30:/tmp/home/root# echo $checksums
```

New Solution:

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/4842dc4e-9cf7-4802-9520-16d42ff92c5a)

```
Admin@GT-BE98_Pro-DE30:/tmp/home/root# checksums="$(curl -Ls --retry 4 --retry-delay 5 https://www.asuswrt-merlin.net/download | sed -n '/<p><strong>SHA256 signatures:<\/strong><\/p>/,/<\/pre>/p' | sed -n '/<pre[^>]*>/,/<\/pre>/p' | sed -e 's/<[^>]*>//g' | sed '1d')"
Admin@GT-BE98_Pro-DE30:/tmp/home/root# echo "$checksums"
a29aa9167c7f7aa540e999455ab764a6ae5aabc6582aef83b9ba3d3e343c66cd  RT-AC5300_386.13_0.trx
f75106e22417c68607aacc2e94869b8c184f5c639c4fca06a61d2df945f45f86  RT-AC68U_386.13_0.trx
6e2a22ccad92385d6adcd5269892e0202a0099ecf40c2c030ffd82230b82847d  RT-AC88U_386.13_0.trx
fe3ca891e9ca1945bc84400133652dd9fb0367650c99402baa77d5c33d35b55c  GT-AC2900_386.13_2_rog_ubi.w
c1eedff802b910b8f24976af72f5dcd08d858fcc3b6335cf24f8c2f4a32dbedd  GT-AC2900_386.13_2_ubi.w
588a2d8a4beedcd4afdae9b7b5c64227c639a4e88720ccf4690cb70be7da5e38  GT-AX11000_3004_388.7_0_rog_ubi.w
e2edee8d9bd804a72c05a37f0f0e3dfaebd868dd8c52ee8cd01c3543ad4205cd  GT-AX11000_3004_388.7_0_ubi.w
7f481c3c6f13347f3348773b367d1e3234a5d966d0e4b9613659031524ed41c9  GT-AXE11000_3004_388.7_0_pureubi.w
b54127d3942be59a1121fb0d1cc0fade1487fac687e569ca9670911563123940  GT-AXE11000_3004_388.7_0_rog_pureubi.w
4f0c0fa3ec4e35806bda5514566b004645e7652b4e76faeb23633e22e65b5460  RT-AC86U_386.13_2_ubi.w
12297f00c37abaf60f9adddb4803447161e7ef9a78da3c00c1cd4074f358c752  RT-AX56U_3004_388.7_0_pureubi.w
41392de0221fc12129c2c4eb5989f55d50cacf553f72b6433d7a769923d32e35  RT-AX58U_3004_388.7_0_puresqubi.w
1765810f74255ac6f3bfffd8b0ce30fd7282a1faa9e88c0f51be864abcac5537  RT-AX68U_3004_388.7_0_pureubi.w
b420f4127667924f9babd71a569702fcce237c12c3238453ed139919f5869994  RT-AX86U_3004_388.7_0_pureubi.w
e2a9d6e4ffec50310649e3b52ead808484b53449610104dc5074d17bbda6d0a0  RT-AX88U_3004_388.7_0_ubi.w
54dfb37254a6ae7daa400a535b7f1d060694be3ccedde1e1e06f965a6df03e4f  GT-AX11000_PRO_3004_388.7_0_nand_squashfs.pkgtb
306f52bb23086cc745d488938e32cccbb0ee58e67d42191c6c151c36789d3696  GT-AX11000_PRO_3004_388.7_0_rog_nand_squashfs.pkgtb
f6a980a237008b8f58e8e2e116d397cf91383e2a0ea547b976619391aed5c104  GT-AX6000_3004_388.7_0_nand_squashfs.pkgtb
915671597d5cb8d09b21097dafa4bbc0ff90e345d5bf4fe81734fa3276d6b49b  GT-AX6000_3004_388.7_0_rog_nand_squashfs.pkgtb
a40a75248419241e13a87ba384853be1080916c01a3a5d7ea98f32216f6bfbed  GT-AXE16000_3004_388.7_0_nand_squashfs.pkgtb
4ba2a829b195642676493d05e852ae8274ae915916b5e039ea4cbe17dbc1bf1c  GT-AXE16000_3004_388.7_0_rog_nand_squashfs.pkgtb
1c80efa135bd3ac5b4a3706764f78def7077b96797f1ede2885cabedaf3bcdbb  RT-AX86U_PRO_3004_388.7_0_nand_squashfs.pkgtb
8a25c114667e952342225729cff4dd4b1854f0e6beed01536ac08991ef6917ac  RT-AX88U_PRO_3004_388.7_0_nand_squashfs.pkgtb
e56f1b2ee7c4c15b9b6a995e8dcab868b7806c36fa150eb07dd5eb584b53396d  XT12_3004_388.7_0_nand_squashfs.pkgtb
389a9f64210f4e16b2b5f66a25d86354742f55427b6f40f1cd037b0761b5e18d  GT-BE98_PRO_3006_102.1_0_nand_squashfs.pkgtb
d0fbb3f72a77983e4e471d444b43e1287aefd84a3344e0ac79aa43452805f956  RT-BE96U_3006_102.1_0_nand_squashfs.pkgtb


```