### PR TITLE
"Update" Menu Behavior 

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -5875,7 +5875,7 @@ _ShowMainMenu_()
       printf "\n ${GRNct}up${NOct}.  Update $SCRIPT_NAME Script Now"
       printf "\n${padStr}[Version ${GRNct}${DLRepoVersion}${NOct} Available for Download]\n"
    else
-      printf "\n ${GRNct}up${NOct}.  Force Update $SCRIPT_NAME Script Now"
+      printf "\n ${GRNct}up${NOct}.  Force Update $SCRIPT_NAME Script"
       printf "\n${padStr}[No Update Available]\n"
    fi
 

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -5872,11 +5872,9 @@ _ShowMainMenu_()
    # Check for new script updates #
    if [ "$scriptUpdateNotify" != "0" ]
    then
-      forceScriptUpdateOption=""
       printf "\n ${GRNct}up${NOct}.  Update $SCRIPT_NAME Script Now"
       printf "\n${padStr}[Version ${GRNct}${DLRepoVersion}${NOct} Available for Download]\n"
    else
-      forceScriptUpdateOption="force"
       printf "\n ${GRNct}up${NOct}.  Force Update $SCRIPT_NAME Script Now"
       printf "\n${padStr}[No Update Available]\n"
    fi
@@ -6181,8 +6179,6 @@ do
    # Check if the directory exists again before attempting to navigate to it
    [ -d "$FW_BIN_DIR" ] && cd "$FW_BIN_DIR"
 
-   forceScriptUpdateOption=""
-
    _ShowMainMenu_
    printf "Enter selection:  " ; read -r userChoice
    echo
@@ -6210,7 +6206,7 @@ do
           else _Approve_FW_Update_
           fi
           ;;
-      up) _SCRIPTUPDATE_ "$forceScriptUpdateOption"
+      up) _SCRIPTUPDATE_
           ;;
       ad) _advanced_options_menu_
           ;;

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -5872,7 +5872,7 @@ _ShowMainMenu_()
    # Check for new script updates #
    if [ "$scriptUpdateNotify" != "0" ]
    then
-      printf "\n ${GRNct}up${NOct}.  Update $SCRIPT_NAME Script Now"
+      printf "\n ${GRNct}up${NOct}.  Update $SCRIPT_NAME Script"
       printf "\n${padStr}[Version ${GRNct}${DLRepoVersion}${NOct} Available for Download]\n"
    else
       printf "\n ${GRNct}up${NOct}.  Force Update $SCRIPT_NAME Script"


### PR DESCRIPTION
Working the update command.
This is the current behavior after your PR: https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/pull/261

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/f1b18552-c8f8-4a4c-bc1a-642847cc2430)

However, this is not what I intended.
I only want the forceupdate to be used in specific situations.

1. When a user calls a forceupdate command externally such as: `/jffs/scripts/MerlinAU.sh forceupdate` like this below:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/b1a8d360-5211-4ff5-a905-e12db49df8c6)
2. When changing the branches from dev to stable or vise versa such as: `/jffs/scripts/MerlinAU.sh develop:` like this below:
![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/6132a594-f253-4908-9a92-42bce648025d)

However when in the menu, if there is no update available, instead of using the force update, we should just use the regular update, like this:

![image](https://github.com/ExtremeFiretop/MerlinAutoUpdate-Router/assets/1971404/f9ee4755-dba2-42ce-a81c-b804559c56e1)

This allows the user to review what they are about to do interactively, without "jumping the gun" so to speak :)