### PR TITLE
Clarify Email Content

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1339,6 +1339,7 @@ readonly hookScriptTagStr="#Added by $ScriptFNameTag#"
 
 # Postponement Days for F/W Update Check #
 FW_UpdatePostponementDays="$(Get_Custom_Setting FW_New_Update_Postponement_Days)"
+FW_UpdateDays="$(Get_Custom_Setting FW_New_Update_Expected_Run_Date)"
 
 ##----------------------------------------##
 ## Modified by Martinski W. [2024-Feb-18] ##
@@ -1438,7 +1439,11 @@ _CreateEMailContent_()
 
    rm -f "$tempEMailContent" "$tempEMailBodyMsg"
 
-   subjectStr="F/W Update Status for $MODEL_ID"
+   if [ -s "$tempNodeEMailList" ]; then
+        subjectStr="F/W Update Status for $node_lan_hostname"
+   else
+        subjectStr="F/W Update Status for $MODEL_ID"
+   fi
    fwInstalledVersion="$(_GetCurrentFWInstalledLongVersion_)"
    fwNewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
 
@@ -1459,6 +1464,7 @@ _CreateEMailContent_()
              echo "A new F/W Update version <b>${fwNewUpdateVersion}</b> is available for the <b>${MODEL_ID}</b> router."
              printf "\nThe F/W version that is currently installed:\n<b>${fwInstalledVersion}</b>\n"
              printf "\nNumber of days to postpone flashing the new F/W Update version: <b>${FW_UpdatePostponementDays}</b>\n"
+             printf "\nThe firmware update is expected to occur on: <b>${FW_UpdateDays}</b>\n"
            } > "$tempEMailBodyMsg"
            ;;
        AGGREGATED_UPDATE_NOTIFICATION)


### PR DESCRIPTION
Clarify Email Content as requested by:

https://www.snbforums.com/threads/merlinau-v1-2-6-the-ultimate-firmware-auto-updater-now-available-in-amtm.88577/post-920655

Also, noticed that when the primary emails about updates for the nodes it looked a bit weird:

![image](https://github.com/user-attachments/assets/ad8eead6-d9a1-4780-bd3b-e908d597ff02)

Basically I'd get an update, the subject made it sound like the primary had an update, but then reading you could tell it was a node update. 

So I addressed both my nitpick and the user request at the same time.