### PR TITLE
Remove Starting Set_FW_UpdateZIP_DirectoryPath

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,12 +4,12 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Aug-07
+# Last Modified: 2024-Aug-10
 ###################################################################
 set -u
 
 ## Set version for each Production Release ##
-readonly SCRIPT_VERSION=1.2.7
+readonly SCRIPT_VERSION=1.2.8
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="master"
@@ -4759,9 +4759,9 @@ _RunBackupmon_()
     return 0
 }
 
-##----------------------------------------##
-## Modified by Martinski W. [2024-Jul-31] ##
-##----------------------------------------##
+##------------------------------------------##
+## Modified by ExtremeFiretop [2024-Aug-08] ##
+##------------------------------------------##
 _RunOfflineUpdateNow_()
 {
     local offlineConfigFile="${SETTINGS_DIR}/offline_updates.txt"


### PR DESCRIPTION
Now that it's no longer a CLI switch/parameter and is instead a combination, we no longer need the Set_FW_UpdateZIP_DirectoryPath_ function at the start. 

They will already be in the advanced options menu, if they want to change the directory, they can use the function from the advanced options menu (option 1)

It was only originally included when the design was to be a CLI entry-point. 
(Feels a little weird now to have it as the starting function now)