### PR TITLE
Small Improvements to Changelog Verification

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -5328,8 +5328,8 @@ _SelectOfflineUpdateFile_()
             printf "\nRelease version: ${GRNct}${release_version}${NOct}\n"
             printf "\n---------------------------------------------------\n"
             _WaitForEnterKey_
-			Update_Custom_Settings FW_New_Update_Notification_Vers "$release_version"
-			Update_Custom_Settings FW_New_Update_Notification_Date "$(date +"$FW_UpdateNotificationDateFormat")"
+            Update_Custom_Settings FW_New_Update_Notification_Vers "$release_version"
+            Update_Custom_Settings FW_New_Update_Notification_Date "$(date +"$FW_UpdateNotificationDateFormat")"
             clear
             return 0
         else

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1502,7 +1502,7 @@ _CreateEMailContent_()
    if [ $# -eq 0 ] || [ -z "$1" ] ; then return 1 ; fi
    local fwInstalledVersion  fwNewUpdateVersion
    local savedInstalledVersion  savedNewUpdateVersion
-   local subjectStr  emailBodyTitle=""
+   local subjectStr  emailBodyTitle=""  release_version
 
    rm -f "$tempEMailContent" "$tempEMailBodyMsg"
 
@@ -1511,7 +1511,12 @@ _CreateEMailContent_()
    else subjectStr="F/W Update Status for $MODEL_ID"
    fi
    fwInstalledVersion="$(_GetCurrentFWInstalledLongVersion_)"
-   fwNewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
+   if ! "$offlineUpdateTrigger"
+   then
+        fwNewUpdateVersion="$(_GetLatestFWUpdateVersionFromRouter_ 1)"
+   else
+        fwNewUpdateVersion="$(Get_Custom_Setting "FW_New_Update_Notification_Vers")"
+   fi
 
    # Remove "_rog" or "_tuf" suffix to avoid version comparison failures #
    fwInstalledVersion="$(echo "$fwInstalledVersion" | sed 's/_\(rog\|tuf\)$//')"
@@ -6065,7 +6070,7 @@ Please manually update to version $MinSupportedFirmwareVers or higher to use thi
     _SendEMailNotification_ START_FW_UPDATE_STATUS
 
     ##------------------------------------------##
-    ## Modified by ExtremeFiretop [2024-Jun-30] ##
+    ## Modified by ExtremeFiretop [2024-Sep-07] ##
     ##------------------------------------------##
 
     curl_response="$(curl -k "${routerURLstr}/login.cgi" \
@@ -6084,10 +6089,8 @@ Please manually update to version $MinSupportedFirmwareVers or higher to use thi
 
     if echo "$curl_response" | grep -Eq 'url=index\.asp|url=GameDashboard\.asp'
     then
-        if ! "$offlineUpdateTrigger"
-        then
-            _SendEMailNotification_ POST_REBOOT_FW_UPDATE_SETUP
-        fi
+
+        _SendEMailNotification_ POST_REBOOT_FW_UPDATE_SETUP
 
         if [ -f /opt/bin/diversion ]
         then

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,12 +4,12 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Sep-02
+# Last Modified: 2024-Sep-07
 ###################################################################
 set -u
 
 ## Set version for each Production Release ##
-readonly SCRIPT_VERSION=1.3.0
+readonly SCRIPT_VERSION=1.3.1
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="dev"
@@ -5230,7 +5230,7 @@ _GetOfflineFirmwareVersion_()
 }
 
 ##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Aug-06] ##
+## Modified by ExtremeFiretop [2024-Sep-07] ##
 ##------------------------------------------##
 _SelectOfflineUpdateFile_()
 {
@@ -5328,6 +5328,8 @@ _SelectOfflineUpdateFile_()
             printf "\nRelease version: ${GRNct}${release_version}${NOct}\n"
             printf "\n---------------------------------------------------\n"
             _WaitForEnterKey_
+			Update_Custom_Settings FW_New_Update_Notification_Vers "$release_version"
+			Update_Custom_Settings FW_New_Update_Notification_Date "$(date +"$FW_UpdateNotificationDateFormat")"
             clear
             return 0
         else


### PR DESCRIPTION
Description of the Bug/Issue:

When doing an offline firmware update this morning on my ASUS GT-BE98 Pro to the newest alpha build version 3006.102.2_alpha1 using MerlinAU, I noticed that it failed to find the correct changelog file even though the changelog file is present and valid in the directories as found below:

![image](https://github.com/user-attachments/assets/33995584-8723-435f-97a1-b8802ade68e2)

The source of the issue is this line in the changelog verification function:

`release_version="$(Get_Custom_Setting "FW_New_Update_Notification_Vers")"`

This line is what MerlinAU uses to determine which changelog to look for. 
As seen by the above screenshot it's looking for the NG file instead of the 3006 file on my 3006 router.

**Possible Resolutions:**

**1.** Different logic for offline changelog selection than production. 
(Based on installed firmware version instead of update firmware version)

- **My thoughts:** 
- I dislike this idea., because some routers may some day move from the NG changelog to the  3006 changelog and the current production logic allows for this to work.

**2.** I could simply update the entry in the file, or disable the changelog verification.

- **My Thoughts:**
- I dislike this idea, I shouldn't ever need to update that settings file manually outside of testing, if I'm a new user, that entry will be TBD as seen above, now I highly doubt a new user would ever use the offline function as their first move, but we should still correctly account for this situation, as well as I shouldn't need to disable changelog verification to allow the flash to happen. Especially if a changelog is present and valid.

**3.** Update the offline logic to update the production file entries if it's used to do a firmware update. This would allow the script to find the correct changelog file without impacting production logic.

- **My thoughts:**
- I like this idea the best, so I've opted to update the file entries if a user triggers an offline update.

With the noticed solution implemented, re-running gave the expected results as seen below:
![image](https://github.com/user-attachments/assets/83ab9bb9-6710-4c64-902f-494353d4cfee)
