### PR TITLE
Removing Cron Jobs from 3rd-party Add-Ons

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2024-Sep-15
+# Last Modified: 2024-Sep-19
 ###################################################################
 set -u
 
@@ -6251,7 +6251,7 @@ Please manually update to version $MinSupportedFirmwareVers or higher to use thi
         _RemoveCronJobsFromAddOns_
 
         # *WARNING*: NO MORE logging at this point & beyond #
-        /sbin/ejusb -1 0 -u 1
+        /sbin/ejusb -1 0 -u 1 2>/dev/null
 
         nohup curl -k "${routerURLstr}/upgrade.cgi" \
         --referer "${routerURLstr}/Advanced_FirmwareUpgrade_Content.asp" \


### PR DESCRIPTION
Added code to remove cron jobs from 3rd-party Add-Ons right before ejecting the USB-attached drive and starting the actual F/W Update process. This is an effort to eliminate the possibility of a cron job starting to execute and accessing the USB drive filesystem.