### PR TITLE
Fix Post Update Release Lock Email Issue

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -6264,6 +6264,8 @@ Please manually update to version ${GRNct}${MinSupportedFirmwareVers}${NOct} or 
         --cookie /tmp/cookie.txt > /tmp/upload_response.txt 2>&1 &
         curlPID=$!
 
+        _ReleaseLock_
+
         #----------------------------------------------------------#
         # In the rare case that the F/W Update gets "stuck" for
         # some reason & the "curl" cmd never returns, we create
@@ -6287,7 +6289,6 @@ Please manually update to version ${GRNct}${MinSupportedFirmwareVers}${NOct} or 
         # reboot by itself after the process returns, do it now.
         #----------------------------------------------------------#
         sleep 180
-        _ReleaseLock_
         /sbin/service reboot
     else
         Say "${REDct}**ERROR**${NOct}: Router Login failed."

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -6327,7 +6327,6 @@ _PostUpdateEmailNotification_()
    local theWaitDelaySecs=10
    local maxWaitDelaySecs=600  #10 minutes#
    local curWaitDelaySecs=0
-   local USBMountPoint
    #---------------------------------------------------------
    # Wait until all services are started, including NTP
    # so the system clock is updated with correct time.
@@ -6358,7 +6357,6 @@ _PostRebootRunNow_()
    local theWaitDelaySecs=10
    local maxWaitDelaySecs=600  #10 minutes#
    local curWaitDelaySecs=0
-   local USBMountPoint
    #---------------------------------------------------------
    # Wait until all services are started, including NTP
    # so the system clock is updated with correct time.

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -1435,7 +1435,7 @@ FW_ZIP_FPATH="${FW_ZIP_DIR}/${FW_FileName}.zip"
 ##----------------------------------------------##
 # The built-in F/W hook script file to be used for
 # setting up persistent jobs to run after a reboot.
-readonly hookScriptFName="wan-event"
+readonly hookScriptFName="services-start"
 readonly hookScriptFPath="${SCRIPTS_PATH}/$hookScriptFName"
 readonly hookScriptTagStr="#Added by $ScriptFNameTag#"
 
@@ -1905,9 +1905,9 @@ _DelPostUpdateEmailNotifyScriptHook_()
    fi
 }
 
-##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Nov-12] ##
-##------------------------------------------##
+##----------------------------------------##
+## Modified by Martinski W. [2024-May-17] ##
+##----------------------------------------##
 _AddPostUpdateEmailNotifyScriptHook_()
 {
    local hookScriptFile  jobHookAdded=false
@@ -1920,9 +1920,7 @@ _AddPostUpdateEmailNotifyScriptHook_()
         echo "#!/bin/sh"
         echo "# $hookScriptFName"
         echo "#"
-        echo "if [ "$1" = "0" ] && [ "$2" = "connected" ]; then"
         echo "$POST_UPDATE_EMAIL_SCRIPT_HOOK"
-        echo "fi"
       } > "$hookScriptFile"
    #
    elif ! grep -qE "$POST_UPDATE_EMAIL_SCRIPT_JOB" "$hookScriptFile"
@@ -1960,9 +1958,9 @@ _DelPostRebootRunScriptHook_()
    fi
 }
 
-##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Nov-12] ##
-##------------------------------------------##
+##----------------------------------------##
+## Modified by Martinski W. [2024-May-17] ##
+##----------------------------------------##
 _AddPostRebootRunScriptHook_()
 {
    local hookScriptFile  jobHookAdded=false
@@ -1975,9 +1973,7 @@ _AddPostRebootRunScriptHook_()
         echo "#!/bin/sh"
         echo "# $hookScriptFName"
         echo "#"
-        echo "if [ "$1" = "0" ] && [ "$2" = "connected" ]; then"
         echo "$POST_REBOOT_SCRIPT_HOOK"
-        echo "fi"
       } > "$hookScriptFile"
    #
    elif ! grep -qE "$POST_REBOOT_SCRIPT_JOB" "$hookScriptFile"
@@ -6341,23 +6337,8 @@ _PostUpdateEmailNotification_()
       # Check if services are ready
       if [ "$(nvram get ntp_ready)" -eq 1 ] && \
          [ "$(nvram get start_service_ready)" -eq 1 ] && \
-         [ "$(nvram get success_start_service)" -eq 1 ]; then
-
-          # If sendEMailNotificationsFlag is true, check AMTM configuration
-          if "$sendEMailNotificationsFlag" 
-          then
-              if _CheckEMailConfigFileFromAMTM_ 0 
-              then
-                  echo "All services are ready."
-                  sleep 60
-                  break
-              fi
-          else
-              echo "All services are ready."
-              sleep 60
-              break
-          fi
-      fi
+         [ "$(nvram get success_start_service)" -eq 1 ]
+      then sleep 60 ; break; fi
 
       echo "Waiting for all services to be started [$theWaitDelaySecs secs.]..."
       sleep $theWaitDelaySecs
@@ -6388,23 +6369,8 @@ _PostRebootRunNow_()
       # Check if services are ready
       if [ "$(nvram get ntp_ready)" -eq 1 ] && \
          [ "$(nvram get start_service_ready)" -eq 1 ] && \
-         [ "$(nvram get success_start_service)" -eq 1 ]; then
-
-          # If sendEMailNotificationsFlag is true, check AMTM configuration
-          if "$sendEMailNotificationsFlag" 
-          then
-              if _CheckEMailConfigFileFromAMTM_ 0 
-              then
-                  echo "All services are ready."
-                  sleep 60
-                  break
-              fi
-          else
-              echo "All services are ready."
-              sleep 60
-              break
-          fi
-      fi
+         [ "$(nvram get success_start_service)" -eq 1 ]
+      then sleep 60 ; break; fi
 
       echo "Waiting for all services to be started [$theWaitDelaySecs secs.]..."
       sleep $theWaitDelaySecs
@@ -6436,9 +6402,9 @@ _DelCronJobRunScriptHook_()
    fi
 }
 
-##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Nov-12] ##
-##------------------------------------------##
+##----------------------------------------##
+## Modified by Martinski W. [2024-May-17] ##
+##----------------------------------------##
 _AddCronJobRunScriptHook_()
 {
    local hookScriptFile  jobHookAdded=false
@@ -6451,9 +6417,7 @@ _AddCronJobRunScriptHook_()
         echo "#!/bin/sh"
         echo "# $hookScriptFName"
         echo "#"
-        echo "if [ "$1" = "0" ] && [ "$2" = "connected" ]; then"
         echo "$CRON_SCRIPT_HOOK"
-        echo "fi"
       } > "$hookScriptFile"
    #
    elif ! grep -qE "$CRON_SCRIPT_JOB" "$hookScriptFile"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -6328,7 +6328,7 @@ _PostUpdateEmailNotification_()
    Update_Custom_Settings FW_New_Update_Changelog_Approval TBD
 
    local theWaitDelaySecs=10
-   local maxWaitDelaySecs=360  #6 minutes#
+   local maxWaitDelaySecs=600  #10 minutes#
    local curWaitDelaySecs=0
    local USBMountPoint
    #---------------------------------------------------------
@@ -6348,12 +6348,12 @@ _PostUpdateEmailNotification_()
               if _CheckEMailConfigFileFromAMTM_ 0 
               then
                   echo "All services are ready."
-                  sleep 30
+                  sleep 60
                   break
               fi
           else
               echo "All services are ready."
-              sleep 30
+              sleep 60
               break
           fi
       fi
@@ -6374,7 +6374,7 @@ _PostRebootRunNow_()
    _DelPostRebootRunScriptHook_
 
    local theWaitDelaySecs=10
-   local maxWaitDelaySecs=360  #6 minutes#
+   local maxWaitDelaySecs=600  #10 minutes#
    local curWaitDelaySecs=0
    local USBMountPoint
    #---------------------------------------------------------
@@ -6395,12 +6395,12 @@ _PostRebootRunNow_()
               if _CheckEMailConfigFileFromAMTM_ 0 
               then
                   echo "All services are ready."
-                  sleep 30
+                  sleep 60
                   break
               fi
           else
               echo "All services are ready."
-              sleep 30
+              sleep 60
               break
           fi
       fi

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -6342,16 +6342,14 @@ _PostUpdateEmailNotification_()
          [ "$(nvram get start_service_ready)" -eq 1 ] && \
          [ "$(nvram get success_start_service)" -eq 1 ]; then
 
-          # If sendEMailNotificationsFlag is true, check USB mount point
-          if "$sendEMailNotificationsFlag" then
-              # Attempt to retrieve the USB mount point
-              USBMountPoint="$(_GetDefaultUSBMountPoint_)"
-              if [ -n "$USBMountPoint" ]; then
-                  echo "All services are ready and USB mount point found: $USBMountPoint"
+          # If sendEMailNotificationsFlag is true, check AMTM configuration
+          if "$sendEMailNotificationsFlag" 
+          then
+              if _CheckEMailConfigFileFromAMTM_ 0 
+              then
+                  echo "All services are ready."
                   sleep 30
                   break
-              else
-                  echo "Waiting for USB mount point..."
               fi
           else
               echo "All services are ready."
@@ -6391,16 +6389,14 @@ _PostRebootRunNow_()
          [ "$(nvram get start_service_ready)" -eq 1 ] && \
          [ "$(nvram get success_start_service)" -eq 1 ]; then
 
-          # If sendEMailNotificationsFlag is true, check USB mount point
-          if "$sendEMailNotificationsFlag" then
-              # Attempt to retrieve the USB mount point
-              USBMountPoint="$(_GetDefaultUSBMountPoint_)"
-              if [ -n "$USBMountPoint" ]; then
-                  echo "All services are ready and USB mount point found: $USBMountPoint"
+          # If sendEMailNotificationsFlag is true, check AMTM configuration
+          if "$sendEMailNotificationsFlag" 
+          then
+              if _CheckEMailConfigFileFromAMTM_ 0 
+              then
+                  echo "All services are ready."
                   sleep 30
                   break
-              else
-                  echo "Waiting for USB mount point..."
               fi
           else
               echo "All services are ready."

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -6367,7 +6367,8 @@ _PostRebootRunNow_()
    while [ "$curWaitDelaySecs" -lt "$maxWaitDelaySecs" ]
    do
       # Check if services are ready
-      if [ "$(nvram get ntp_ready)" -eq 1 ] && \
+      if [ -d "$FW_ZIP_BASE_DIR" ] && \
+         [ "$(nvram get ntp_ready)" -eq 1 ] && \
          [ "$(nvram get start_service_ready)" -eq 1 ] && \
          [ "$(nvram get success_start_service)" -eq 1 ]
       then sleep 60 ; break; fi


### PR DESCRIPTION
Untested at this time.

Currently there is an issue where the email does not always send post-reboot after an upgrade.
It was initially reported by Tom ([visortgw](https://www.snbforums.com/posts/921646/reactions)) and I was able to replicate it.

Essentially to me the issue in short so far seems to be the services-start can be triggered before an active internet connection; or before amtm is ready, which is required to send the email.