### PR TITLE
WebGUI Cron Schedule Input

### DIFF
--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -39,6 +39,7 @@ var custom_settings = {};
 var shared_custom_settings = {};
 var ajax_custom_settings = {};
 let isFormSubmitting = false;
+let FW_NewUpdateVersAvailable = '';
 
 // Define color formatting //
 const CYANct = "<span style='color:cyan;'>";
@@ -1145,11 +1146,10 @@ function InitializeFields()
         var fwUpdateAvailableElement = document.getElementById('fwUpdateAvailable');
         var fwVersionInstalledElement = document.getElementById('fwVersionInstalled');
 
-        var isFwUpdateAvailable = false; // Initialize the flag
-
+        var isFwUpdateAvailable = false; // Initialize the flag //
         if (fwUpdateAvailableElement && fwVersionInstalledElement)
         {
-            var fwUpdateAvailable = FW_New_Update_Available
+            var fwUpdateAvailable = FW_NewUpdateVersAvailable;
             var fwVersionInstalled = fwVersionInstalledElement.textContent.trim();
 
             // Convert both to numeric forms //
@@ -1252,7 +1252,7 @@ function InitializeFields()
 }
 
 /**----------------------------------------**/
-/** Modified by Martinski W. [2025-Jan-18] **/
+/** Modified by Martinski W. [2025-Jan-26] **/
 /**----------------------------------------**/
 function GetConfigSettings()
 {
@@ -1266,19 +1266,19 @@ function GetConfigSettings()
         },
         success: function(data)
         {
-            // Tokenize the data while respecting quoted values
-            var tokenList = tokenize(data);
+            // Tokenize the data while respecting quoted values //
+            var tokenList = Tokenize(data);
 
-            for (var i = 0; i < tokenList.length; i++)
+            for (var indx = 0; indx < tokenList.length; indx++)
             {
-                var token = tokenList[i];
+                var tokenStr = tokenList[indx];
 
-                if (token.includes('='))
+                if (tokenStr.includes('='))
                 {
                     // Handle "key=value" format //
-                    var splitIndex = token.indexOf('=');
-                    var key = token.substring(0, splitIndex).trim();
-                    var value = token.substring(splitIndex + 1).trim();
+                    var splitIndex = tokenStr.indexOf('=');
+                    var key = tokenStr.substring(0, splitIndex).trim();
+                    var value = tokenStr.substring(splitIndex + 1).trim();
 
                     // Remove surrounding quotes if present
                     if (value.startsWith('"') && value.endsWith('"'))
@@ -1289,26 +1289,25 @@ function GetConfigSettings()
                 else
                 {
                     // Handle "key value" format //
-                    var key = token.trim();
+                    var key = tokenStr.trim();
                     var value = '';
 
                     // Ensure there's a next token for the value //
-                    if (i + 1 < tokenList.length)
+                    if (indx + 1 < tokenList.length)
                     {
-                        value = tokenList[i + 1].trim();
+                        value = tokenList[indx + 1].trim();
 
                         // Remove surrounding quotes if present //
                         if (value.startsWith('"') && value.endsWith('"'))
                         { value = value.substring(1, value.length - 1); }
 
                         AssignAjaxSetting(key, value);
-                        i++; // Skip the next token as it's already processed
+                        indx++; // Skip next token as it's already processed //
                     }
                     else
                     { console.warn(`No value found for key: ${key}`); }
                 }
             }
-
             console.log("AJAX Custom Settings Loaded:", ajax_custom_settings);
 
             // Merge both server and AJAX settings //
@@ -1322,11 +1321,11 @@ function GetConfigSettings()
     });
 }
 
-// Helper function to tokenize the input string, respecting quoted substrings //
-function tokenize(input)
+// Tokenize input string, respecting quoted substrings //
+function Tokenize(inputStr)
 {
     var regex = /(?:[^\s"]+|"[^"]*")+/g;
-    return input.match(regex) || [];
+    return inputStr.match(regex) || [];
 }
 
 /**----------------------------------------**/
@@ -1366,7 +1365,7 @@ function AssignAjaxSetting(key, value)
            break;
 
        case keyUpper === 'FW_NEW_UPDATE_NOTIFICATION_VERS':
-           FW_New_Update_Available = value.trim();
+           FW_NewUpdateVersAvailable = value.trim();
            break;
 
        case keyUpper === 'FW_NEW_UPDATE_EMAIL_CC_ADDRESS':
@@ -1796,7 +1795,7 @@ function getFirstNonEmptyValue(ids)
 /** Modified by Martinski W. [2025-Jan-05] **/
 /**----------------------------------------**/
 // Function to format and display the Router IDs //
-function formatRouterIDs()
+function FormatRouterIDs()
 {
     // Define the order of NVRAM keys to search for Model ID and Product ID
     var modelKeys = ["nvram_odmpid", "nvram_wps_modelnum", "nvram_model", "nvram_build_name"];
@@ -1840,7 +1839,7 @@ function stripHTML(html)
 /** Modified by Martinski W. [2025-Jan-05] **/
 /**----------------------------------------**/
 // Function to format the Firmware Version Installed //
-function formatFirmwareVersion()
+function FormatFirmwareVersion()
 {
     var fwVersionElement = document.getElementById('fwVersionInstalled');
     if (fwVersionElement)
@@ -1866,9 +1865,10 @@ function formatFirmwareVersion()
 }
 
 // Modify the existing DOMContentLoaded event listener to include the new function
-document.addEventListener("DOMContentLoaded", function() {
-    formatRouterIDs();
-    formatFirmwareVersion(); // Call the new formatting function
+document.addEventListener("DOMContentLoaded", function()
+{
+    FormatRouterIDs();
+    FormatFirmwareVersion();
 });
 
 function initializeCollapsibleSections()

--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -29,7 +29,7 @@
 <script language="JavaScript" type="text/javascript">
 
 /**----------------------------**/
-/** Last Modified: 2025-Jan-25 **/
+/** Last Modified: 2025-Jan-26 **/
 /** Intended for 1.4.0 Release **/
 /**----------------------------**/
 
@@ -865,14 +865,16 @@ function togglePassword()
 }
 
 /**----------------------------------------**/
-/** Modified by Martinski W. [2025-Jan-11] **/
+/** Modified by Martinski W. [2025-Jan-26] **/
 /**----------------------------------------**/
 // Converts F/W version string with the format: "3006.102.5.2" //
 // to a number of the format: '30061020502'  //
-function FWVersionStrToNum(verStr)
+function FWVersionStrToNum (verStr)
 {
-    // If it's empty or null, treat as ZERO //
-    if (!verStr) return 0;
+    if (verStr === null ||
+        verStr.length === 0 ||
+        verStr === 'TBD')
+    { return 0; }
 
     let nonProductionVersionWeight = 0;
     let foundAlphaBetaVersion = verStr.match (/([Aa]lpha|[Bb]eta)/);
@@ -987,7 +989,7 @@ function handleROGFWBuildTypeVisibility()
 }
 
 /**----------------------------------------**/
-/** Modified by Martinski W. [2025-Jan-24] **/
+/** Modified by Martinski W. [2025-Jan-26] **/
 /**----------------------------------------**/
 function InitializeFields()
 {
@@ -1122,11 +1124,16 @@ function InitializeFields()
         setStatus('emailNotificationsStatus', custom_settings.FW_New_Update_EMail_Notification);
 
         // Handle fwNotificationsDate as a date //
+        let notifyFullDateStr, notifyDateTimeStr;
         if (fwNotificationsDate && custom_settings.FW_New_Update_Notifications_Date)
         {
-            let theDateTimeStr = custom_settings.FW_New_Update_Notifications_Date.split ('_');
-            let notifyDatestr = theDateTimeStr[0] + ' ' + theDateTimeStr[1];
-            fwNotificationsDate.innerHTML = InvYLWct + notifyDatestr + InvCLEAR;
+            notifyFullDateStr = custom_settings.FW_New_Update_Notifications_Date;
+            if (notifyFullDateStr.includes('_'))
+            {
+                notifyDateTimeStr = notifyFullDateStr.split ('_');
+                notifyFullDateStr = notifyDateTimeStr[0] + ' ' + notifyDateTimeStr[1];
+            }
+            fwNotificationsDate.innerHTML = InvYLWct + notifyFullDateStr + InvCLEAR;
         }
         else if (fwNotificationsDate)
         { fwNotificationsDate.innerHTML = InvYLWct + "TBD" + InvCLEAR; }

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2025-Jan-25
+# Last Modified: 2025-Jan-26
 ###################################################################
 set -u
 
@@ -357,7 +357,7 @@ _ReleaseLock_()
    else lockType="$1"
    fi
    if [ -s "$LockFilePath" ] && \
-      [ "$(cat "$LockFilePath" | wc -l)" -gt 1 ]
+      [ "$(wc -l < "$LockFilePath")" -gt 1 ]
    then
        if [ -z "$lockType" ]
        then sed -i "/^$$|/d" "$LockFilePath"

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,7 +4,7 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2025-Jan-22
+# Last Modified: 2025-Jan-25
 ###################################################################
 set -u
 
@@ -2228,7 +2228,7 @@ _ActionsAfterNewConfigSettings_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Jan-21] ##
+## Modified by Martinski W. [2025-Jan-25] ##
 ##----------------------------------------##
 _UpdateConfigFromWebUISettings_()
 {
@@ -2244,7 +2244,7 @@ _UpdateConfigFromWebUISettings_()
 
        # Extract 'MerlinAU_' entries excluding 'version' #
        grep "^MerlinAU_" "$SHARED_SETTINGS_FILE" | grep -v "_version" > "$TEMPFILE"
-       sed -i "s/^MerlinAU_//g;s/ /=/g" "$TEMPFILE"
+       sed -i 's/^MerlinAU_//g;s/ /=/g' "$TEMPFILE"
 
        while IFS='' read -r line || [ -n "$line" ]
        do
@@ -2261,6 +2261,10 @@ _UpdateConfigFromWebUISettings_()
                    Say "**ERROR**: Could NOT update directory path [$keySettingValue]"
                fi
                continue
+           fi
+           if [ "$keySettingName" = "FW_New_Update_Cron_Job_Schedule" ]
+           then  # Replace delimiter char placed by the WebGUI #
+               keySettingValue="$(echo "$keySettingValue" | sed 's/|/ /g')"
            fi
            Update_Custom_Settings "$keySettingName" "$keySettingValue"
        done < "$TEMPFILE"
@@ -9748,7 +9752,7 @@ _ShowMainMenuOptions_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Jan-15] ##
+## Modified by Martinski W. [2025-Jan-25] ##
 ##----------------------------------------##
 _ShowAdvancedOptionsMenu_()
 {
@@ -9764,6 +9768,7 @@ _ShowAdvancedOptionsMenu_()
    printf "\n  ${GRNct}1${NOct}.  Set Directory for F/W Update File"
    printf "\n${padStr}[Current Path: ${GRNct}${FW_ZIP_DIR}${NOct}]\n"
 
+   FW_UpdateCronJobSchedule="$(Get_Custom_Setting FW_New_Update_Cron_Job_Schedule)"
    printf "\n  ${GRNct}2${NOct}.  Set F/W Update Cron Schedule"
    printf "\n${padStr}[Current Schedule: ${GRNct}${FW_UpdateCronJobSchedule}${NOct}]"
    printf "\n${padStr}[${GRNct}%s${NOct}]\n" "$(_TranslateCronSchedHR_ "$FW_UpdateCronJobSchedule")"


### PR DESCRIPTION
Implemented the "**Schedule for F/W Update Checks**" user input on the WebGUI page. Currently, the design is meant to be simple and intuitive to allow users to set up the most common cron schedules with standard parameters that should satisfy the requirements of the vast majority of users (~95% perhaps?)

If a user wants to have a more complex cron schedule (e.g. with a specific list of days of month) then the recommendation would be to use the SSH CLI menus. In such cases, when the WebGUI page cannot display the cron schedule parameters, some of the page elements would be either shown as empty or grayed out to indicate that those parameters are not represented on the WebGUI.

![MerlinAU_WebGUI_CronSchedule#1](https://github.com/user-attachments/assets/e423b451-0ede-4411-9f06-90472c1e164e)

![MerlinAU_WebGUI_CronSchedule#2](https://github.com/user-attachments/assets/f191d343-d50e-4a22-b02e-c610143895de)

![MerlinAU_WebGUI_CronSchedule#3](https://github.com/user-attachments/assets/a01bbe2e-50c8-4d42-90f4-90beaf7cf4f7)

