### PR TITLE
Fix ROG and TUG Build Type Selection from WebUI

### DIFF
--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -960,7 +960,7 @@ function handleROGFWBuildTypeVisibility()
 
         // ROG Model Check //
         var isROGModel = routerModel.includes('GT-');
-        var hasROGFWBuildType = custom_settings.hasOwnProperty('FW_New_Update_ROGFWBuildType');
+        var hasROGFWBuildType = custom_settings.hasOwnProperty('ROGBuild');
         var rogFWBuildRow = document.getElementById('rogFWBuildRow');
 
         if (!isROGModel || !hasROGFWBuildType)
@@ -974,7 +974,7 @@ function handleROGFWBuildTypeVisibility()
 
         // TUF Model Check //
         var isTUFModel = routerModel.includes('TUF-');
-        var hasTUFWBuildType = custom_settings.hasOwnProperty('FW_New_Update_TUFWBuildType');
+        var hasTUFWBuildType = custom_settings.hasOwnProperty('TUFBuild');
         var tufFWBuildRow = document.getElementById('tuffFWBuildRow');
 
         if (!isTUFModel || !hasTUFWBuildType)
@@ -1098,10 +1098,10 @@ function InitializeFields()
         SetUpEmailNotificationFields();
 
         if (rogFWBuildType)
-        { rogFWBuildType.value = custom_settings.FW_New_Update_ROGFWBuildType || 'ROG'; }
+        { rogFWBuildType.value = custom_settings.ROGBuild || 'ROG'; }
 
         if (tuffFWBuildType)
-        { tuffFWBuildType.value = custom_settings.FW_New_Update_TUFWBuildType || 'TUF'; }
+        { tuffFWBuildType.value = custom_settings.TUFBuild || 'TUF'; }
 
         if (changelogCheckEnabled)
         { changelogCheckEnabled.checked = (custom_settings.CheckChangeLog === 'ENABLED'); }
@@ -1439,11 +1439,11 @@ function AssignAjaxSetting (keyName, keyValue)
            break;
 
        case keyUpper === 'ROGBUILD':
-           ajax_custom_settings.FW_New_Update_ROGFWBuildType = (keyValue === 'ENABLED') ? 'ROG' : 'Pure';
+           ajax_custom_settings.ROGBuild = (keyValue === 'ENABLED') ? 'ROG' : 'Pure';
            break;
 
        case keyUpper === 'TUFBUILD':
-           ajax_custom_settings.FW_New_Update_TUFWBuildType = (keyValue === 'ENABLED') ? 'TUF' : 'Pure';
+           ajax_custom_settings.TUFBuild = (keyValue === 'ENABLED') ? 'TUF' : 'Pure';
            break;
 
        case keyUpper === 'FW_NEW_UPDATE_NOTIFICATION_DATE':
@@ -1622,8 +1622,8 @@ function SaveActionsConfig()
         "MerlinAU_FW_New_Update_EMail_CC_Address",
         "MerlinAU_Allow_Updates_OverVPN",
         "MerlinAU_Allow_Script_Auto_Update",
-        "MerlinAU_FW_New_Update_ROGFWBuildType",
-        "MerlinAU_FW_New_Update_TUFWBuildType"
+        "MerlinAU_ROGBuild",
+        "MerlinAU_TUFBuild"
     ];
     ADVANCED_KEYS.forEach(function (key){
         if (shared_custom_settings.hasOwnProperty(key))
@@ -1701,13 +1701,15 @@ function SaveAdvancedConfig()
     // 7) ROG/TUF F/W Build Type - handle conditional rows if visible
     let rogFWBuildRow = document.getElementById('rogFWBuildRow');
     let rogFWBuildType = document.getElementById('rogFWBuildType');
-    if (rogFWBuildRow && rogFWBuildRow.style.display !== 'none' && rogFWBuildType)
-    { advanced_settings.FW_New_Update_ROGFWBuildType = rogFWBuildType.value || 'ROG'; }
+    if (rogFWBuildRow && rogFWBuildRow.style.display !== 'none' && rogFWBuildType) {
+        advanced_settings.ROGBuild = (rogFWBuildType.value === 'ROG') ? 'ENABLED' : 'DISABLED';
+    }
 
     let tufFWBuildRow = document.getElementById('tuffFWBuildRow');
     let tuffFWBuildType = document.getElementById('tuffFWBuildType');
-    if (tufFWBuildRow && tufFWBuildRow.style.display !== 'none' && tuffFWBuildType)
-    { advanced_settings.FW_New_Update_TUFWBuildType = tuffFWBuildType.value || 'TUF'; }
+    if (tufFWBuildRow && tufFWBuildRow.style.display !== 'none' && tuffFWBuildType) {
+        advanced_settings.TUFBuild = (tuffFWBuildType.value === 'TUF') ? 'ENABLED' : 'DISABLED';
+    }
 
     // Prefix only Advanced settings
     var prefixedAdvancedSettings = PrefixCustomSettings(advanced_settings, 'MerlinAU_');


### PR DESCRIPTION
@Martinski4GitHub 

Sorry for the delay buddy, been busy with work and personal life things, I totally just realized I never even messaged you the crazy story I wanted to tell you. I'll do that shortly! I hope everything is going well with you! Did you manage to get everything setup at home now with the new hardware?

Anyways, this PR is to fix the ROG and TUF build type selection; small bug really.
The key names were wrong (compared to what the script is expecting) and same with the values. Instead of outputting "ROG" or "Pure" it should be outputting "ENABLED" or "DISABLED" since the new _Migrate_Settings_ function changes the values.

That's more or less the end of my testing with the ROG and TUF builds, the only thing I noticed remaining with these tests is that the WebUI did not display the Build options unless I first selected one in the script.

So for example, a fresh install of the script would have the build values as "TBD" or missing from the file completely. In such an instance the WebUI does not detect or display the build options, it seems to be related to this line in the .asp file:

`if (!isTUFModel || !hasTUFWBuildType) `
or 
`if (!isROGModel || !hasROGFWBuildType)`

 Which is requiring the build type to already be in the file.
 I could of course remove the requirement for !hasROGFWBuildType or !hasTUFWBuildType; however, just because the model is a GT or a TUF model does not mean it will have TUF or ROG builds (i.e RMerlin has dropped support for ROG builds on GT models on 3006 firmware)
 
 So this I believe is why I made it dependent on there being a value already inside. (So it was determined by the script) Now this isn't a real problem because likely setting the build type would be done right away post install, even if it wasn't on and the user forgot to set it; the script on first flash would populate the settings file with a default built type, and then it would show on the WebUI.

But maybe best we look into a way to detect and populate that file as soon as the script is loaded. Similar to backupmon with this code:

```
currentBackupOption="$(Get_Custom_Setting "FW_Auto_Backupmon")"
if [ -f "/jffs/scripts/backupmon.sh" ]
then
    # If setting is empty, add it to the configuration file #
    if [ "$currentBackupOption" = "TBD" ]
    then
        Update_Custom_Settings FW_Auto_Backupmon "ENABLED"
    fi
else
    # If the configuration setting exists, delete it #
    if [ "$currentBackupOption" != "TBD" ]
    then
        Delete_Custom_Settings "FW_Auto_Backupmon"
    fi
fi
```

Thoughts or opinions bud?