### PR TITLE
Fix WebUI Changelog Check Approval

### DIFF
--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -1229,20 +1229,51 @@ function InitializeFields()
             // Always display the button
             approveChangelogButton.style.display = 'inline-block';
 
-            // Condition: Enable button only if
-            // 1. Changelog Check is enabled
-            // 2. Changelog Approval is neither empty nor "TBD"
-            if (isChangelogCheckEnabled && changelogApprovalValue && changelogApprovalValue !== 'TBD')
+            // Decide whether we want "Approve" or "Block"
+            if (changelogApprovalValue === 'APPROVED')
             {
-                approveChangelogButton.disabled = false; // Enable the button
-                approveChangelogButton.style.opacity = '1'; // Fully opaque
-                approveChangelogButton.style.cursor = 'pointer'; // Pointer cursor for enabled state
+                // Change button text to "Block Changelog"
+                approveChangelogButton.value = "Block Changelog";
+
+                // Make sure it calls a new function that sends a block command
+                approveChangelogButton.onclick = function() {
+                    blockChangelog();
+                    return false;  // Prevent default form submission
+                };
+
+                approveChangelogButton.disabled = false; 
+                approveChangelogButton.style.opacity = '1'; 
+                approveChangelogButton.style.cursor = 'pointer';
+            }
+            else if (changelogApprovalValue === 'BLOCKED')
+            {
+                // If it’s "BLOCKED", e.g. "Approve Changelog" again:
+                approveChangelogButton.value = "Approve Changelog";
+                approveChangelogButton.onclick = function() {
+                    changelogApproval();
+                    return false;
+                };
+                approveChangelogButton.disabled = false; 
             }
             else
             {
-                approveChangelogButton.disabled = true; // Disable the button
-                approveChangelogButton.style.opacity = '0.5'; // Grayed out appearance
-                approveChangelogButton.style.cursor = 'not-allowed'; // Indicate disabled state
+                approveChangelogButton.value = "Approve Changelog";
+
+                // Condition: Enable button only if
+                // 1. Changelog Check is enabled
+                // 2. Changelog Approval is neither empty nor "TBD"
+                if (isChangelogCheckEnabled && changelogApprovalValue && changelogApprovalValue !== 'TBD')
+                {
+                    approveChangelogButton.disabled = false; // Enable the button
+                    approveChangelogButton.style.opacity = '1'; // Fully opaque
+                    approveChangelogButton.style.cursor = 'pointer'; // Pointer cursor for enabled state
+                }
+                else
+                {
+                    approveChangelogButton.disabled = true; // Disable the button
+                    approveChangelogButton.style.opacity = '0.5'; // Grayed out appearance
+                    approveChangelogButton.style.cursor = 'not-allowed'; // Indicate disabled state
+                }
             }
         }
 
@@ -1776,6 +1807,22 @@ function changelogApproval()
    document.form.action_wait.value = 10;
    showLoading();
    document.form.submit();
+}
+
+function blockChangelog()
+{
+    console.log("Blocking Changelog...");
+
+    if (!confirm("Are you sure you want to block this changelog?"))
+    {
+        return;
+    }
+
+    document.form.action_script.value = 'start_MerlinAUblockchangelog';
+    document.form.action_wait.value   = 10;
+
+    showLoading();
+    document.form.submit();
 }
 
 /**----------------------------------------**/

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -10395,13 +10395,23 @@ then
                        sleep 1
                        ;;
                    "${SCRIPT_NAME}approvechangelog")
-                       local currApprovalStatus="$(Get_Custom_Setting "FW_New_Update_Changelog_Approval")"
+                       currApprovalStatus="$(Get_Custom_Setting "FW_New_Update_Changelog_Approval")"
                        if [ "$currApprovalStatus" = "BLOCKED" ]
                        then
                            Update_Custom_Settings "FW_New_Update_Changelog_Approval" "APPROVED"
                        elif [ "$currApprovalStatus" = "APPROVED" ]
                        then
                            Update_Custom_Settings "FW_New_Update_Changelog_Approval" "BLOCKED"
+                       fi
+                       ;;
+                   "${SCRIPT_NAME}blockchangelog")
+                       currApprovalStatus="$(Get_Custom_Setting "FW_New_Update_Changelog_Approval")"
+                       if [ "$currApprovalStatus" = "APPROVED" ]
+                       then
+                           Update_Custom_Settings "FW_New_Update_Changelog_Approval" "BLOCKED"
+                       elif [ "$currApprovalStatus" = "BLOCKED" ]
+                       then
+                           Update_Custom_Settings "FW_New_Update_Changelog_Approval" "APPROVED"
                        fi
                        ;;
                    "${SCRIPT_NAME}checkupdate" | \


### PR DESCRIPTION
Hey @Martinski4GitHub 

Recently reviewed the changelog approval status code and noticed a bug which I fixed below.
Also wanted to change some of the behavior of the WebUI button so I added some new logic.

Below is examples of everything working as expected:

- **High risk detected on script load (as normal):**
![image](https://github.com/user-attachments/assets/136fccf0-4b38-4bc0-a927-b945ad761236)


- **WebUI detects blocked changelog to approve:**
![image](https://github.com/user-attachments/assets/3c2f0cca-1e96-46c3-af8c-bfd8bbaf35b5)


- **Once approved, we give the option to block again (same as the core shell script):**
![image](https://github.com/user-attachments/assets/fb386304-038c-4e28-8536-4fa058591828)
