### PR TITLE
Fix The Update Check Status Post Upgrade

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -14,6 +14,10 @@ readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="dev"
 
+##FOR TESTING/DEBUG ONLY##
+if true ; then SCRIPT_BRANCH="WebFun" ; fi
+##FOR TESTING/DEBUG ONLY##
+
 ##----------------------------------------##
 ## Modified by Martinski W. [2024-Jul-03] ##
 ##----------------------------------------##
@@ -8901,6 +8905,7 @@ _DoStartupInit_()
        _AutoStartupHook_ create 2>/dev/null
        _AutoServiceEvent_ create 2>/dev/null
    fi
+
 }
 
 ##----------------------------------------##
@@ -8933,6 +8938,7 @@ _DoInstallation_()
 
    if ! _AcquireLock_ cliMenuLock
    then Say "Exiting..." ; exit 1 ; fi
+   _ConfirmCronJobForFWAutoUpdates_
    _MainMenu_
 }
 

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -14,10 +14,6 @@ readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="dev"
 
-##FOR TESTING/DEBUG ONLY##
-if true ; then SCRIPT_BRANCH="WebFun" ; fi
-##FOR TESTING/DEBUG ONLY##
-
 ##----------------------------------------##
 ## Modified by Martinski W. [2024-Jul-03] ##
 ##----------------------------------------##
@@ -8905,7 +8901,6 @@ _DoStartupInit_()
        _AutoStartupHook_ create 2>/dev/null
        _AutoServiceEvent_ create 2>/dev/null
    fi
-
 }
 
 ##----------------------------------------##


### PR DESCRIPTION
Fix The Update Check Status Post Upgrade in the WebUI

Issue seems to be it does not check or set the **FW_UPDATE_CHECK** value in the settings file post upgrade as seen below:

![image](https://github.com/user-attachments/assets/c70a4038-45aa-419a-b441-f1633ffc7226)

We should be seeing this run:

![image](https://github.com/user-attachments/assets/dc5b5da8-3661-46c5-b1c0-d14301ac08ad)

Which sets the value.

Solution seems to be to simply add the missing: _ConfirmCronJobForFWAutoUpdates_ within the _DoInstallation_ routine.
Without this, on first upgrade after running: `sh /jffs/scripts/MerlinAU.sh develop` 

We get this result in the configuration file:

![image](https://github.com/user-attachments/assets/e9df0c1f-7e8a-4cc2-b888-5bcd2fb41267)

Simply running the script a second time also fixes the "bug" but we can add this to the Install routine I think without any impact.