### PR TITLE
Fix iOS Checkboxes

### DIFF
--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -1623,7 +1623,6 @@ function InitializeFields()
                 $('#autobackupEnabled').prop('disabled', false);
                 setCheckboxDisabledById('autobackupEnabled', false);
                 autobackupEnabled.checked = (custom_settings.FW_Auto_Backupmon === 'ENABLED');
-                autobackupEnabled.style.opacity = '1'; // Fully opaque
             }
             else
             {
@@ -1632,7 +1631,7 @@ function InitializeFields()
                 $('#autobackupEnabled').prop('disabled', true);
                 setCheckboxDisabledById('autobackupEnabled', true);
                 autobackupEnabled.checked = false; // Optionally uncheck
-                autobackupEnabled.style.opacity = '0.5'; // Grayed out appearance
+
             }
         }
 

--- a/MerlinAU.asp
+++ b/MerlinAU.asp
@@ -87,6 +87,15 @@ function ConsoleLogDEBUG (debugMsg, debugVar)
    { console.log(debugMsg, debugVar); }
 }
 
+// Helper function to set the disabled state and inline opacity for a checkbox by its ID
+function setCheckboxDisabledById(elementId, isDisabled) {
+  var checkbox = document.getElementById(elementId);
+  if (checkbox) {
+    checkbox.disabled = isDisabled;
+    checkbox.style.opacity = isDisabled ? '0.5' : '1';
+  }
+}
+
 /**-------------------------------------**/
 /** Added by Martinski W. [2025-Jan-13] **/
 /**-------------------------------------**/
@@ -284,26 +293,43 @@ function ToggleDaysOfWeek (isEveryXDayChecked, numberOfDays)
    let numOfDays = ['1', 'X'];
    if (isEveryXDayChecked)
    {
-       for (var indx = 0; indx < daysOfWeekNames.length; indx++)
-       { $('#fwSched_' + daysOfWeekNames[indx].toUpperCase()).prop('disabled', true); }
+       for (var indx = 0; indx < daysOfWeekNames.length; indx++) {
+           var checkboxId = 'fwSched_' + daysOfWeekNames[indx].toUpperCase();
+           $('#' + checkboxId).prop('disabled', true);
+           setCheckboxDisabledById(checkboxId, true);
+       }
        if (numberOfDays === 'X')
-       { $('#fwScheduleXDAYS').prop('disabled', false); }
+       { 
+           $('#fwScheduleXDAYS').prop('disabled', false);
+           setCheckboxDisabledById('fwScheduleXDAYS', false);
+       }
        else
-       { $('#fwScheduleXDAYS').prop('disabled', true); }
+       { 
+           $('#fwScheduleXDAYS').prop('disabled', true);
+           setCheckboxDisabledById('fwScheduleXDAYS', true);
+       }
    }
    else
    {
-       for (var indx = 0; indx < daysOfWeekNames.length; indx++)
-       { $('#fwSched_' + daysOfWeekNames[indx].toUpperCase()).prop('disabled', false); }
+       for (var indx = 0; indx < daysOfWeekNames.length; indx++) {
+           var checkboxId = 'fwSched_' + daysOfWeekNames[indx].toUpperCase();
+           $('#' + checkboxId).prop('disabled', false);
+           setCheckboxDisabledById(checkboxId, false);
+       }
        if (numberOfDays === 'X')
-       { $('#fwScheduleXDAYS').prop('disabled', true); }
+       { 
+           $('#fwScheduleXDAYS').prop('disabled', true);
+           setCheckboxDisabledById('fwScheduleXDAYS', true);
+       }
    }
    for (var indx = 0; indx < numOfDays.length; indx++)
    {
        if (numOfDays[indx] !== numberOfDays)
        {
-           $('#fwSchedBoxDAYS' + numOfDays[indx]).prop('checked', false);
-           $('#fwSchedBoxDAYS' + numOfDays[indx]).prop('disabled', false);
+           var checkboxId = 'fwSchedBoxDAYS' + numOfDays[indx];
+           $('#'+ checkboxId).prop('checked', false);
+           $('#'+ checkboxId).prop('disabled', false);
+           setCheckboxDisabledById(checkboxId, false);
        }
    }
 }
@@ -1594,6 +1620,8 @@ function InitializeFields()
             {
                 // If the setting exists, enable the checkbox and set its state
                 autobackupEnabled.disabled = false;
+                $('#autobackupEnabled').prop('disabled', false);
+                setCheckboxDisabledById('autobackupEnabled', false);
                 autobackupEnabled.checked = (custom_settings.FW_Auto_Backupmon === 'ENABLED');
                 autobackupEnabled.style.opacity = '1'; // Fully opaque
             }
@@ -1601,6 +1629,8 @@ function InitializeFields()
             {
                 // If the setting is missing, disable and gray out the checkbox
                 autobackupEnabled.disabled = true;
+                $('#autobackupEnabled').prop('disabled', true);
+                setCheckboxDisabledById('autobackupEnabled', true);
                 autobackupEnabled.checked = false; // Optionally uncheck
                 autobackupEnabled.style.opacity = '0.5'; // Grayed out appearance
             }
@@ -1707,11 +1737,15 @@ function InitializeFields()
             if (!isChangelogCheckEnabled || !approvalValue || approvalValue === 'TBD')
             {
                 approveChangelogCheck.disabled = true;
+                $('#approveChangelogCheck').prop('disabled', true);
+                setCheckboxDisabledById('approveChangelogCheck', true);
                 approveChangelogCheck.checked = false;
             }
             else
             {
                 approveChangelogCheck.disabled = false;
+                $('#approveChangelogCheck').prop('disabled', false);
+                setCheckboxDisabledById('approveChangelogCheck', false);
                 if (approvalValue === 'APPROVED')
                 { approveChangelogCheck.checked = true; }
                 else


### PR DESCRIPTION
@Martinski4GitHub 

As you know; I have no devices to test this change, but I think the issue is the fact that for the "Enable Automatic Backups" checkbox we manually set an inline style that sets its opacity when disabled. For example, in your InitializeFields() function we have:

```
autobackupEnabled.style.opacity = '1'; // Fully opaque
autobackupEnabled.style.opacity = '0.5'; // Grayed out appearance
```

But for every other checkbox, we don't set it that way and instead the other checkboxs like the days-of-the-week checkboxes or the changelog approval, the code only changes their disabled state via:

` jQuery’s .prop('disabled', true).`

So to try and resolve this I attempted to standardize the way we disable them all using both jQuery the DOM property.