### PR TITLE
Improved Subject Line for Script Update Emails

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -3034,9 +3034,9 @@ _GetLatestFWUpdateVersionFromRouter_()
    echo "$newVersionStr" ; return "$retCode"
 }
 
-##------------------------------------------##
-## Modified by ExtremeFiretop [2024-Apr-14] ##
-##------------------------------------------##
+##----------------------------------------##
+## Modified by Martinski W. [2024-Apr-14] ##
+##----------------------------------------##
 _CreateEMailContent_()
 {
    if [ $# -eq 0 ] || [ -z "$1" ] ; then return 1 ; fi
@@ -3046,10 +3046,15 @@ _CreateEMailContent_()
 
    rm -f "$tempEMailContent" "$tempEMailBodyMsg"
 
-   if [ -s "$tempNodeEMailList" ]
-   then subjectStr="F/W Update Status for $node_lan_hostname"
-   else subjectStr="F/W Update Status for $MODEL_ID"
+   local subjectStrTag="F/W Update Status"
+   if echo "$1" | grep -q '._SCRIPT_UPDATE_.'
+   then subjectStrTag="Script Update Status"
    fi
+   if [ -s "$tempNodeEMailList" ]
+   then subjectStr="$subjectStrTag for $node_lan_hostname"
+   else subjectStr="$subjectStrTag for $MODEL_ID"
+   fi
+
    fwInstalledVersion="$(_GetCurrentFWInstalledLongVersion_)"
    if ! "$offlineUpdateTrigger"
    then

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MerlinAU - AsusWRT-Merlin Firmware Auto Updater
-## v1.4.2
-## 2025-Apr-13
+## v1.4.3
+## 2025-Apr-14
 
 ## WebUI:
 ![image](https://github.com/user-attachments/assets/a2197262-ca35-451a-8645-311896e1495e)


### PR DESCRIPTION
Modified code to set a more appropriate Subject line for the "Script Update Status" email notifications.

The previous **Subject** line was misleading because the email is **not** about a **F/W Update Status**.

![MerlinAU_v1 4 3 _ScriptUpdateEmail1](https://github.com/user-attachments/assets/1ea58e1e-58d0-48b2-8039-195a025410ee)

The modified Subject line "Script Update Status ..." is more appropriate:

![MerlinAU_v1 4 3 _ScriptUpdateEmail2](https://github.com/user-attachments/assets/453ff580-8406-4a8b-b31f-90b1be885535)

![MerlinAU_v1 4 3 _ScriptUpdateEmail3](https://github.com/user-attachments/assets/96e44071-c84e-467f-90ca-4cba34eaee34)
