### PR TITLE
Modified RAM Requirements for F/W Flash Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MerlinAU - AsusWRT-Merlin Firmware Auto Updater
 ## v1.4.7
-## 2025-May-18
+## 2025-Jun-??
 
 ## WebUI:
 ![image](https://github.com/user-attachments/assets/a2197262-ca35-451a-8645-311896e1495e)


### PR DESCRIPTION
Made changes in the memory requirements for routers with **512MB** RAM to be less restrictive and allow the process to continue with the F/W flash.