### PR TITLE
Silcence ap warnings

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,12 +4,12 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2025-Jun-02
+# Last Modified: 2025-Jun-05
 ###################################################################
 set -u
 
 ## Set version for each Production Release ##
-readonly SCRIPT_VERSION=1.4.7
+readonly SCRIPT_VERSION=1.4.8
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="master"
@@ -4787,11 +4787,8 @@ _GetNodeInfo_()
 
     if [ $? -ne 0 ]
     then
-        _UpdateLoginPswdCheckHelper_ FAILURE
-        printf "\n${REDct}Login failed for AiMesh Node [$NodeIP_Address].${NOct}\n"
         return 1
     fi
-    _UpdateLoginPswdCheckHelper_ SUCCESS
 
     # Retrieve the HTML content #
     htmlContent="$(curl -s -k "${NodeURLstr}/appGet.cgi?hook=nvram_get(productid)%3bnvram_get(asus_device_list)%3bnvram_get(cfg_device_list)%3bnvram_get(firmver)%3bnvram_get(buildno)%3bnvram_get(extendno)%3bnvram_get(webs_state_flag)%3bnvram_get(odmpid)%3bnvram_get(wps_modelnum)%3bnvram_get(model)%3bnvram_get(build_name)%3bnvram_get(lan_hostname)%3bnvram_get(webs_state_info)%3bnvram_get(label_mac)" \

--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -9,7 +9,7 @@
 set -u
 
 ## Set version for each Production Release ##
-readonly SCRIPT_VERSION=1.4.8
+readonly SCRIPT_VERSION=1.4.7
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="master"


### PR DESCRIPTION
For AiMesh nodes, the password is always the same as the primary with no options to change, so we don't need the passwordloginchecker helper for those.

And for an AP, they can be set to any password that doesn't match the primary, so displaying invalid password for those seems incorrect.