### PR TITLE
Correct sed(1) RE to extract version from the Gnuton FW filename.

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4996,7 +4996,7 @@ _GetLatestFWUpdateVersionFromGitHub_()
             # Extract the version portion from the URL #
             urlVersion="$(echo "$theURL" \
                 | grep -oE "${PRODUCT_ID}_[^ ]*\.(w|pkgtb)" \
-                | sed "s/${PRODUCT_ID}_//;s/.w$//;s/.pkgtb$//;s/.ubi$//;s/_/./g;s/-gnuton[0-9][0-9]*\$//" | head -n1)"
+                | sed "s/${PRODUCT_ID}_//;s/\\.w$//;s/\\.pkgtb$//;s/_\\(ubi\\|puresqubi\\|nand_squashfs\\)$//;s/_/./g;s/-gnuton[0-9][0-9]*$//" | head -n1)"
 
             if [ "$urlVersion" = "$routerVersion" ]
             then
@@ -5059,7 +5059,7 @@ GetLatestFirmwareMD5URL()
             # Extract the version portion from the URL #
             md5Version="$(echo "$theURL" \
                 | grep -oE "${PRODUCT_ID}_[^ ]*\.(md5)" \
-                | sed "s/${PRODUCT_ID}_//;s/.md5$//;s/.w$//;s/.pkgtb$//;s/.ubi$//;s/_/./g;s/-gnuton[0-9][0-9]*\$//" | head -n1)"
+                | sed "s/${PRODUCT_ID}_//;s/\\.md5$//;s/\\.w$//;s/\\.pkgtb$//;s/_\\(ubi\\|puresqubi\\|nand_squashfs\\)$//;s/_/./g;s/-gnuton[0-9][0-9]*$//" | head -n1)"
 
             if [ "$md5Version" = "$routerVersion" ]
             then


### PR DESCRIPTION
So far, I've seen `ubi`, `nand_squashfs`, and `puresqubi`. While I'm at it, tighten up the REs.

Fixes updating models such as the ZenWiFi XT8 (RT-AX95Q) that use `puresqubi` or `nand_squashfs` Gnuton images.