### PR TITLE
Messaging Improvement when entering Login Password.

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,13 +4,13 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2026-Apr-06
+# Last Modified: 2026-Apr-08
 ###################################################################
 set -u
 
 ## Set version for each Production Release ##
 readonly SCRIPT_VERSION=1.6.1
-readonly SCRIPT_VERSTAG="26040607"
+readonly SCRIPT_VERSTAG="26040823"
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="dev"
@@ -5003,7 +5003,8 @@ _GetLoginCredentials_()
 
     while [ "$retry" = "yes" ]
     do
-        printf "=== Login Credentials ===\n\n"
+        printf "==== Router Login Password ====\n"
+        printf "[${MGNTct}<TAB>${NOct} key to show/hide, ${MGNTct}<ESC>${NOct} key to exit]\n\n"
         _GetPasswordInput_ "Enter password for user ${GRNct}${userName}${NOct}"
 
         if [ -z "$thePWSDstring" ]
@@ -5021,14 +5022,14 @@ _GetLoginCredentials_()
         if [ "$thePWSDstring" != "$oldPWSDstring" ]
         then
             _UpdateLoginPswdCheckHelper_ NewPSWD
-            savedMsgStr="${GRNct}New credentials saved.${NOct}"
+            savedMsgStr="Login credentials are saved."
             oldPWSDstring="$thePWSDstring"
         else
             _UpdateLoginPswdCheckHelper_ OldPSWD
-            savedMsgStr="${GRNct}Credentials remain unchanged.${NOct}"
+            savedMsgStr="Credentials remain unchanged."
         fi
-        printf "\n${savedMsgStr}\n"
-        printf "Encoded Credentials:\n"
+        printf "\n\n${GRNct}${savedMsgStr}${NOct}\n"
+        printf "\nEncoded Credentials:\n"
         printf "${GRNct}${loginCredsENC}${NOct}\n"
 
         if _WaitForYESorNO_ "\nWould you like to test the current login credentials?"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MerlinAU - AsusWRT-Merlin Firmware Auto Updater
 
 ## v1.6.1
-## 2026-Apr-05
+## 2026-Apr-08
 
 ## WebUI:
 ![image](https://github.com/user-attachments/assets/9c1dff99-9c13-491b-a7fa-aff924d5f02e)


### PR DESCRIPTION
Added messages to the "**Router Login Password**" prompt to let the user know how to show/hide the password string, and how to exit the input prompt.

Sample screenshot showing additional messaging:

![MerlinAU_v1 6 1_CLI_Menu_LoginPswdMsgs](https://github.com/user-attachments/assets/3c4ba589-ba89-4178-98cc-1cd183dc0e40)

I've been wanting to do this for a while, but it was at the bottom of my "list of things to improve" and didn't get to it until now. The `<TAB>` and `<ESC>` key functionality when entering the password has been there for a long time, but it's not intuitive to users.






