### PR TITLE
Fix for Password with Special Chars

### DIFF
--- a/MerlinAU.sh
+++ b/MerlinAU.sh
@@ -4,13 +4,13 @@
 #
 # Original Creation Date: 2023-Oct-01 by @ExtremeFiretop.
 # Official Co-Author: @Martinski W. - Date: 2023-Nov-01
-# Last Modified: 2026-Jul-30
+# Last Modified: 2026-Aug-16
 ###################################################################
 set -u
 
 ## Set version for each Production Release ##
 readonly SCRIPT_VERSION=1.6.6
-readonly SCRIPT_VERSTAG="26073018"
+readonly SCRIPT_VERSTAG="26081603"
 readonly SCRIPT_NAME="MerlinAU"
 ## Set to "master" for Production Releases ##
 SCRIPT_BRANCH="dev"
@@ -1648,7 +1648,7 @@ Get_Custom_Setting()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Jan-20] ##
+## Modified by Martinski W. [2026-Aug-16] ##
 ##----------------------------------------##
 Update_Custom_Settings()
 {
@@ -1678,7 +1678,8 @@ Update_Custom_Settings()
                 then
                     if [ "$setting_value" != "$(grep "^$setting_type" "$CONFIG_FILE" | cut -f2 -d' ')" ]
                     then
-                        sed -i "s/^$setting_type.*/$setting_type $setting_value/" "$CONFIG_FILE"
+                        fixedVal="$(echo "$setting_value" | sed 's/[\/&]/\\&/g')"
+                        sed -i "s/^${setting_type}.*/$setting_type $fixedVal/" "$CONFIG_FILE"
                     fi
                 else
                     echo "$setting_type $setting_value" >> "$CONFIG_FILE"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MerlinAU - AsusWRT-Merlin Firmware Auto Updater
 
 ## v1.6.6
-## 2026-Jul-30
+## 2026-Aug-16
 
 ## WebUI:
 <img width="775" height="1640" alt="image" src="https://github.com/user-attachments/assets/846f889b-b39f-4ffe-a37a-8892ad9b2f7f" />


### PR DESCRIPTION
Fixed code to properly handle saving the base64-encoded password to the add-on's configuration file. This prevents the following error message: `sed: bad option in substitution expression`

See the reported issue in this SNB Forums post:
https://www.snbforums.com/threads/merlinau-v1-6-5-the-ultimate-firmware-auto-updater.96306/page-9#post-1001616


